### PR TITLE
build prefix incorrect

### DIFF
--- a/doc/linux/user_guide.md
+++ b/doc/linux/user_guide.md
@@ -128,6 +128,6 @@ sudo apt install libopencv-dev
 ```console
 cd aditof_sdk
 mkdir build && cd build
-cmake .. -DCMAKE_PREFIX_PATH="opt/glog;opt/protobuf;/opt/websockets"
+cmake .. -DCMAKE_PREFIX_PATH="/opt/glog;/opt/protobuf;/opt/websockets"
 make
 ```


### PR DESCRIPTION
path should be /opt not opt.  This prevents cmake from finding protobuf and fails the build.