### PR TITLE
sdk: target: buffer written to eeprom should be const

### DIFF
--- a/sdk/src/target/eeprom.c
+++ b/sdk/src/target/eeprom.c
@@ -38,7 +38,7 @@ int eeprom_read_buf(eeprom *e, unsigned int addr, unsigned char *buf,
     return 0;
 }
 
-int eeprom_write_buf(eeprom *e, unsigned int addr, unsigned char *buf,
+int eeprom_write_buf(eeprom *e, unsigned int addr, const unsigned char *buf,
                      size_t size) {
     fseek(e->fd, addr, SEEK_SET);
     size_t ret = fwrite(buf, 1, size, e->fd);

--- a/sdk/src/target/eeprom.h
+++ b/sdk/src/target/eeprom.h
@@ -14,7 +14,7 @@ int eeprom_close(eeprom *e);
 /*
  * write the data stored in buff to eeprom
  */
-int eeprom_write_buf(eeprom *e, unsigned int addr, unsigned char *buf,
+int eeprom_write_buf(eeprom *e, unsigned int addr, const unsigned char *buf,
                      size_t size);
 /*
  * read the data from eeprom and store it in buff

--- a/sdk/src/target/local_device.cpp
+++ b/sdk/src/target/local_device.cpp
@@ -617,8 +617,7 @@ aditof::Status LocalDevice::writeEeprom(uint32_t address, const uint8_t *data,
         return Status::GENERIC_ERROR;
     }
 
-    int ret =
-        eeprom_write_buf(&edev, address, const_cast<uint8_t *>(data), length);
+    int ret = eeprom_write_buf(&edev, address, data, length);
     if (ret == -1) {
         LOG(WARNING) << "EEPROM write error";
         return Status::GENERIC_ERROR;


### PR DESCRIPTION
There is no longer a need to cast away the constness of the buffer written to eeprom

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>