### PR TITLE
sdk: Expose details about windows USB device

### DIFF
--- a/sdk/src/windows/usb_device_windows.cpp
+++ b/sdk/src/windows/usb_device_windows.cpp
@@ -1329,5 +1329,6 @@ aditof::Status UsbDevice::applyCalibrationToFrame(uint16_t *frame,
 }
 
 aditof::Status UsbDevice::getDetails(aditof::DeviceDetails &details) const {
+    details = m_deviceDetails;
     return aditof::Status::OK;
 }


### PR DESCRIPTION
Camera could not be constructed because no device information was
provided.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>