### PR TITLE
CMake: add target to copy dlls to examples

### DIFF
--- a/bindings/opencv/CMakeLists.txt
+++ b/bindings/opencv/CMakeLists.txt
@@ -11,3 +11,13 @@ install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/aditof_opencv.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/aditof
 )
+
+if(WIN32)
+    include(FindOpenSSL)
+    add_custom_target(copy-dll-opencv
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:aditof> $<TARGET_FILE_DIR:aditof-opencv-imshow>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:aditof> $<TARGET_FILE_DIR:aditof-opencv-dnn>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OpenSSL::SSL> $<TARGET_FILE_DIR:aditof-opencv-imshow>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OpenSSL::SSL> $<TARGET_FILE_DIR:aditof-opencv-dnn>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,18 @@ add_subdirectory(first-frame)
 include(GNUInstallDirs)
 
 install(PROGRAMS
-    ${CMAKE_CURRENT_BINARY_DIR}/aditof-demo/aditof-demo
-    ${CMAKE_CURRENT_BINARY_DIR}/first-frame/first-frame
+    $<TARGET_FILE:aditof-demo>
+    $<TARGET_FILE:first-frame>
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+
+if(WIN32)
+    include(FindOpenSSL)
+    add_custom_target(copy-dll-example
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:aditof> $<TARGET_FILE_DIR:aditof-demo>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:aditof> $<TARGET_FILE_DIR:first-frame>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OpenSSL::SSL> $<TARGET_FILE_DIR:aditof-demo>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OpenSSL::SSL> $<TARGET_FILE_DIR:first-frame>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()


### PR DESCRIPTION
This custom target can be used to copy important dlls on Windows(#109 ).

Signed-off-by: Daniel Guramulta <Daniel.Guramulta@analog.com>