### PR TITLE
sdk: Move implementations of DeviceEnumeratorInterface to private

### DIFF
--- a/apps/server/server.cpp
+++ b/apps/server/server.cpp
@@ -2,7 +2,6 @@
 #include "aditof/aditof.h"
 #include "aditof/device_construction_data.h"
 #include "aditof/device_enumerator_factory.h"
-#include "aditof/device_enumerator_impl.h"
 #include "aditof/device_factory.h"
 #include "buffer.pb.h"
 

--- a/sdk/src/device_enumerator_ethernet.cpp
+++ b/sdk/src/device_enumerator_ethernet.cpp
@@ -1,4 +1,4 @@
-#include "aditof/device_enumerator_ethernet.h"
+#include "device_enumerator_ethernet.h"
 #include "network.h"
 
 #include <glog/logging.h>

--- a/sdk/src/device_enumerator_ethernet.h
+++ b/sdk/src/device_enumerator_ethernet.h
@@ -1,7 +1,7 @@
 #ifndef DEVICE_ENUMERATOR_ETHERNET_H
 #define DEVICE_ENUMERATOR_ETHERNET_H
 
-#include "device_enumerator_interface.h"
+#include <aditof/device_enumerator_interface.h>
 
 #include <string>
 

--- a/sdk/src/device_enumerator_factory.cpp
+++ b/sdk/src/device_enumerator_factory.cpp
@@ -1,6 +1,7 @@
-#include "aditof/device_enumerator_factory.h"
-#include "aditof/device_enumerator_ethernet.h"
-#include "aditof/device_enumerator_impl.h"
+#include <aditof/device_enumerator_factory.h>
+
+#include "device_enumerator_ethernet.h"
+#include "device_enumerator_impl.h"
 
 std::unique_ptr<DeviceEnumeratorInterface>
 DeviceEnumeratorFactory::buildDeviceEnumerator() {

--- a/sdk/src/device_enumerator_impl.cpp
+++ b/sdk/src/device_enumerator_impl.cpp
@@ -2,4 +2,4 @@
  * common on all operating systems.
  */
 
-#include "aditof/device_enumerator_impl.h"
+#include "device_enumerator_impl.h"

--- a/sdk/src/device_enumerator_impl.h
+++ b/sdk/src/device_enumerator_impl.h
@@ -1,7 +1,7 @@
 #ifndef DEVICE_ENUMERATOR_IMPL_H
 #define DEVICE_ENUMERATOR_IMPL_H
 
-#include "device_enumerator_interface.h"
+#include <aditof/device_enumerator_interface.h>
 
 class DeviceEnumeratorImpl : public DeviceEnumeratorInterface {
   public:

--- a/sdk/src/linux/device_enumerator_linux.cpp
+++ b/sdk/src/linux/device_enumerator_linux.cpp
@@ -1,4 +1,4 @@
-#include "aditof/device_enumerator_impl.h"
+#include "device_enumerator_impl.h"
 #include "utils_linux.h"
 
 #include <dirent.h>

--- a/sdk/src/macos/device_enumerator_macos.cpp
+++ b/sdk/src/macos/device_enumerator_macos.cpp
@@ -1,4 +1,4 @@
-#include "aditof/device_enumerator_impl.h"
+#include "device_enumerator_impl.h"
 
 aditof::Status DeviceEnumeratorImpl::findDevices(
     std::vector<aditof::DeviceConstructionData> &devices) {

--- a/sdk/src/target/dragonboard/device_enumerator_dragonboard.cpp
+++ b/sdk/src/target/dragonboard/device_enumerator_dragonboard.cpp
@@ -1,4 +1,4 @@
-#include "aditof/device_enumerator_impl.h"
+#include "device_enumerator_impl.h"
 
 #include <dirent.h>
 #include <glog/logging.h>

--- a/sdk/src/target/raspberrypi/device_enumerator_raspberry.cpp
+++ b/sdk/src/target/raspberrypi/device_enumerator_raspberry.cpp
@@ -1,4 +1,4 @@
-#include "aditof/device_enumerator_impl.h"
+#include "device_enumerator_impl.h"
 
 #include <dirent.h>
 #include <glog/logging.h>

--- a/sdk/src/windows/device_enumerator_windows.cpp
+++ b/sdk/src/windows/device_enumerator_windows.cpp
@@ -1,4 +1,4 @@
-#include "aditof/device_enumerator_impl.h"
+#include "device_enumerator_impl.h"
 #include "windows_utils.h"
 
 #include <atlstr.h>


### PR DESCRIPTION
There is no reason to expose them in the API.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>