### PR TITLE
bindings: Rework setup.py to skip recompiling the python bindings

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -8,6 +8,10 @@ pybind11_add_module(aditofpython aditofpython.cpp)
 
 target_link_libraries(aditofpython PRIVATE aditof)
 
+get_target_property(target_prefix aditofpython PREFIX)
+get_target_property(target_suffix aditofpython SUFFIX)
+set(TARGET_OUTPUT_NAME "${target_prefix}aditofpython${target_suffix}")
+
 add_subdirectory(examples/dnn)
 
 configure_file(

--- a/cmake/setup.py.cmakein
+++ b/cmake/setup.py.cmakein
@@ -1,17 +1,19 @@
 #!/usr/bin/python
 from distutils.core import setup, Extension
 
-aditof_module = Extension('aditofpython',
-                    define_macros = [('MAJOR_VERSION', '${ADITOF_VERSION_MAJOR}'),
-                                     ('MINOR_VERSION', '${ADITOF_VERSION_MINOR}'),
-                                     ('PATCH_VERSION', '${ADITOF_VERSION_PATCH}')],
-                    include_dirs = ['${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}'],
-                    libraries = ['aditof'],
-                    library_dirs = ['${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}'],
-                    sources = ['${CMAKE_CURRENT_SOURCE_DIR}/aditofpython.cpp'])
+import sys
+if sys.version_info < (3,0):
+  sys.exit('Minimum Python is 3.0')
 
 setup (name = 'aditofpython',
        version = '${VERSION}',
        author = "Analog Devices, Inc",
        description = "Python bindings for the 3D ToF SDK",
-       ext_modules = [aditof_module])
+       packages = [ '' ],
+       package_dir = {
+              '': '${CMAKE_CURRENT_BINARY_DIR}'
+       },
+       package_data = {
+              '': ['${TARGET_OUTPUT_NAME}']
+       }
+)


### PR DESCRIPTION
Since the bindings are built at the build step along with the rest of the project, we want to use these binaries instead of asking setup.py to build them again.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>