### PR TITLE
sdk: SystemImpl: set the camera objects to nullptr after deleting them

### DIFF
--- a/sdk/src/system_impl.cpp
+++ b/sdk/src/system_impl.cpp
@@ -14,6 +14,7 @@ SystemImpl::SystemImpl()
 SystemImpl::~SystemImpl() {
     for (auto &cam : m_cameras) {
         delete cam;
+        cam = nullptr;
     }
 }
 


### PR DESCRIPTION
Clients of the SDK might still hold pointers to this camera objects even after deleting the system object. This pointers should be made nullptr to indicate that they have been deleted.

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>