### PR TITLE
apps: include the server on raspberry pi target platforms

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -5,3 +5,7 @@ if (DRAGONBOARD)
         add_subdirectory(server)
         add_subdirectory(uvc-app)
 endif()
+
+if (RASPBERRYPI)
+        add_subdirectory(server)
+endif()


### PR DESCRIPTION
The server was not included even though it is supported on this platform

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>