### PR TITLE
Changed the calculation of the IR frame in all examples.

### DIFF
--- a/bindings/matlab/source_adaptor.cpp
+++ b/bindings/matlab/source_adaptor.cpp
@@ -284,6 +284,18 @@ int SourceAdaptor::getCurrentHwRange() {
     return cameraDetails.range;
 }
 
+int SourceAdaptor::getCurrentBitCount() {
+    aditof::CameraDetails cameraDetails;
+
+    if (!m_camera) {
+        return 0;
+    }
+
+    m_camera->getDetails(cameraDetails);
+
+    return cameraDetails.bitCount;
+}
+
 std::shared_ptr<aditof::Frame> SourceAdaptor::getFrameFromHwDevice() {
     if (!m_camera) {
         return nullptr;
@@ -509,6 +521,7 @@ void SourceAdaptor::sendFrame(SourceAdaptor *adaptor) {
 
         auto frame = adaptor->getFrameFromHwDevice();
         int currentRange = adaptor->getCurrentHwRange();
+        int currentMaxPixelValue = (1 << adaptor->getCurrentBitCount()) - 1;
 
         imaqkit::frametypes::FRAMETYPE frameType;
 
@@ -517,9 +530,8 @@ void SourceAdaptor::sendFrame(SourceAdaptor *adaptor) {
                 uint16_t *data = nullptr;
                 frame->getData(aditof::FrameDataType::IR, &data);
                 for (int i = 0; i < imageHeight * imageWidth; ++i) {
-                    uint16_t value = (data[i] * (255.0 / currentRange));
-                    imBuffer[i] =
-                        static_cast<uint8_t>(value <= 255 ? value : 255);
+                    uint16_t value = (data[i] * (255.0 / currentMaxPixelValue));
+                    imBuffer[i] = static_cast<uint8_t>(value);
                 }
 
                 frameType = imaqkit::frametypes::MONO8;

--- a/bindings/matlab/source_adaptor.h
+++ b/bindings/matlab/source_adaptor.h
@@ -178,6 +178,8 @@ class SourceAdaptor : public imaqkit::IAdaptor {
 
     int getCurrentHwRange();
 
+    int getCurrentBitCount();
+
     void setDisplayedFrameType(int16_t type);
 
     void setSmallSignalValue(int16_t value);

--- a/bindings/open3D/aditof_open3d.h
+++ b/bindings/open3D/aditof_open3d.h
@@ -35,13 +35,13 @@ Status fromFrameToDepthImg(Frame &frame, int camera_range,
     return Status::OK;
 }
 
-Status fromFrameToIRImg(Frame &frame, int camera_range,
-                        geometry::Image &image) {
+Status fromFrameToIRImg(Frame &frame, int bitCount, geometry::Image &image) {
     FrameDetails frameDetails;
     frame.getDetails(frameDetails);
 
     const int frameHeight = static_cast<int>(frameDetails.height) / 2;
     const int frameWidth = static_cast<int>(frameDetails.width);
+    int max_value_of_IR_pixel = (1 << bitCount) - 1;
 
     uint16_t *irData;
     frame.getData(FrameDataType::IR, &irData);
@@ -54,7 +54,7 @@ Status fromFrameToIRImg(Frame &frame, int camera_range,
     for (int i = 0; i < frameHeight * frameWidth; i++) {
         uint8_t *p =
             static_cast<uint8_t *>(image.data_.data() + i * sizeof(uint8_t));
-        uint16_t value = *(irData + i) * 255.0 / camera_range;
+        uint16_t value = *(irData + i) * 255.0 / max_value_of_IR_pixel;
         *p = static_cast<uint8_t>(value <= 255 ? value : 255);
         p++;
     }

--- a/bindings/open3D/showPointCloud/main.cpp
+++ b/bindings/open3D/showPointCloud/main.cpp
@@ -70,6 +70,7 @@ int main(int argc, char *argv[]) {
     aditof::CameraDetails cameraDetails;
     camera->getDetails(cameraDetails);
     int camera_range = cameraDetails.range;
+    int bitCount = cameraDetails.bitCount;
 
     const size_t REGS_CNT = 5;
     uint16_t afeRegsAddr[REGS_CNT] = {0x4001, 0x7c22, 0xc34a, 0x4001, 0x7c22};
@@ -130,7 +131,7 @@ int main(int argc, char *argv[]) {
         }
 
         geometry::Image ir_image;
-        status = fromFrameToIRImg(frame, camera_range, ir_image);
+        status = fromFrameToIRImg(frame, bitCount, ir_image);
         if (status != Status::OK) {
             LOG(ERROR) << "Could not convert from frame to Image!";
         }

--- a/bindings/opencv/dnn/main.cpp
+++ b/bindings/opencv/dnn/main.cpp
@@ -90,6 +90,7 @@ int main(int argc, char *argv[]) {
     aditof::CameraDetails cameraDetails;
     camera->getDetails(cameraDetails);
     int cameraRange = cameraDetails.range;
+    int bitCount = cameraDetails.bitCount;
 
     aditof::Frame frame;
     status = camera->requestFrame(&frame);
@@ -173,11 +174,16 @@ int main(int argc, char *argv[]) {
         /* Distance factor */
         double distance_scale = 255.0 / cameraRange;
 
+        int max_value_of_IR_pixel = (1 << bitCount) - 1;
+
+        /* Distance factor IR */
+        double distance_scale_ir = 255.0 / max_value_of_IR_pixel;
+
         /* Convert from raw values to values that opencv can understand */
         frameMat.convertTo(frameMat, CV_8U, distance_scale);
         applyColorMap(frameMat, frameMat, cv::COLORMAP_RAINBOW);
 
-        irMat.convertTo(irMat, CV_8U, distance_scale);
+        irMat.convertTo(irMat, CV_8U, distance_scale_ir);
         cv::cvtColor(irMat, irMat, cv::COLOR_GRAY2RGB);
 
         /* Use a combination between ir mat & depth mat as input for the Net as

--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -53,7 +53,8 @@ PYBIND11_MODULE(aditofpython, m) {
         .def_readwrite("mode", &aditof::CameraDetails::mode)
         .def_readwrite("frameType", &aditof::CameraDetails::frameType)
         .def_readwrite("connection", &aditof::CameraDetails::connection)
-        .def_readwrite("range", &aditof::CameraDetails::range);
+        .def_readwrite("range", &aditof::CameraDetails::range)
+        .def_readwrite("bitCount", &aditof::CameraDetails::bitCount);
 
     // Helpers
 

--- a/bindings/python/examples/dnn/dnn.py
+++ b/bindings/python/examples/dnn/dnn.py
@@ -91,7 +91,12 @@ if __name__ == "__main__":
     device.writeAfeRegisters(afeRegsAddr, afeRegsVal, REGS_CNT)
 
     camera_range = camDetails.range
+    bitCount = camDetails.bitCount
     frame = tof.Frame()
+
+    max_value_of_IR_pixel = 2 ** bitCount - 1
+    distance_scale_ir = 255.0 / max_value_of_IR_pixel
+    distance_scale = 255.0 / camera_range
 
     while True:
         # Capture frame-by-frame
@@ -104,18 +109,16 @@ if __name__ == "__main__":
 
         # Creation of the IR image
         ir_map = ir_map[0: int(ir_map.shape[0] / 2), :]
-        ir_map = np.float32(ir_map)
-        distance_scale_ir = 255.0 / camera_range
         ir_map = distance_scale_ir * ir_map
         ir_map = np.uint8(ir_map)
+        ir_map = cv.flip(ir_map, 1)
         ir_map = cv.cvtColor(ir_map, cv.COLOR_GRAY2RGB)
 
         # Creation of the Depth image
         new_shape = (int(depth_map.shape[0] / 2), depth_map.shape[1])
         depth_map = np.resize(depth_map, new_shape)
+        depth_map = cv.flip(depth_map, 1)
         distance_map = depth_map
-        depth_map = np.float32(depth_map)
-        distance_scale = 255.0 / camera_range
         depth_map = distance_scale * depth_map
         depth_map = np.uint8(depth_map)
         depth_map = cv.applyColorMap(depth_map, cv.COLORMAP_RAINBOW)

--- a/bindings/python/examples/showPointCloud/showPointCloud.py
+++ b/bindings/python/examples/showPointCloud/showPointCloud.py
@@ -64,7 +64,12 @@ if __name__ == "__main__":
     device.writeAfeRegisters(afeRegsAddr, afeRegsVal, REGS_CNT)
 
     camera_range = camDetails.range
+    bitCount = camDetails.bitCount
     frame = tof.Frame()
+
+    max_value_of_IR_pixel = 2 ** bitCount - 1
+    distance_scale_ir = 255.0 / max_value_of_IR_pixel
+    distance_scale = 255.0 / camera_range
 
     while True:
         # Capture frame-by-frame
@@ -77,20 +82,17 @@ if __name__ == "__main__":
 
         # Creation of the IR image
         ir_map = ir_map[0: int(ir_map.shape[0] / 2), :]
-        ir_map = np.float32(ir_map)
-        distance_scale_ir = 255.0 / camera_range
         ir_map = distance_scale_ir * ir_map
         ir_map = np.uint8(ir_map)
+        ir_map = cv.flip(ir_map, 1)
         ir_map = cv.cvtColor(ir_map, cv.COLOR_GRAY2RGB)
 
         # Creation of the Depth image
         new_shape = (int(depth_map.shape[0] / 2), depth_map.shape[1])
         depth_map = np.resize(depth_map, new_shape)
-        distance_map = depth_map
-        depth_map = np.float32(depth_map)
-        distance_scale = 255.0 / camera_range
         depth_map = distance_scale * depth_map
-        img_depth = depth_map = np.uint8(depth_map)
+        depth_map = np.uint8(depth_map)
+        img_depth = depth_map = cv.flip(depth_map, 1)
         depth_map = cv.applyColorMap(depth_map, cv.COLORMAP_RAINBOW)
 
         # Show Depth map

--- a/examples/aditof-demo/aditofdemocontroller.cpp
+++ b/examples/aditof-demo/aditofdemocontroller.cpp
@@ -266,6 +266,13 @@ int AdiTofDemoController::getRange() const {
     return cameraDetails.range;
 }
 
+int AdiTofDemoController::getbitCount() const {
+    aditof::CameraDetails cameraDetails;
+    m_cameras[static_cast<unsigned int>(m_cameraInUse)]->getDetails(
+        cameraDetails);
+    return cameraDetails.bitCount;
+}
+
 aditof::Status AdiTofDemoController::enableNoiseReduction(bool en) {
     using namespace aditof;
 

--- a/examples/aditof-demo/aditofdemocontroller.h
+++ b/examples/aditof-demo/aditofdemocontroller.h
@@ -48,6 +48,8 @@ class AdiTofDemoController {
 
     int getRange() const;
 
+    int getbitCount() const;
+
     bool setEthernetConnection(const std::string &ip);
     bool setRegularConnection();
 

--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -1,5 +1,6 @@
 #include "aditofdemoview.h"
 
+#include <glog/logging.h>
 #include <sstream>
 
 #define CVUI_IMPLEMENTATION
@@ -837,9 +838,10 @@ void AdiTofDemoView::_displayIrImage() {
 
         int frameHeight = static_cast<int>(frameDetails.height) / 2;
         int frameWidth = static_cast<int>(frameDetails.width);
+        int max_value_of_IR_pixel = (1 << m_ctrl->getbitCount()) - 1;
 
         m_irImage = cv::Mat(frameHeight, frameWidth, CV_16UC1, irData);
-        m_irImage.convertTo(m_irImage, CV_8U, 255.0 / m_ctrl->getRange());
+        m_irImage.convertTo(m_irImage, CV_8U, 255.0 / max_value_of_IR_pixel);
         flip(m_irImage, m_irImage, 1);
 
         std::unique_lock<std::mutex> imshow_lock(m_imshowMutex);
@@ -865,9 +867,10 @@ void AdiTofDemoView::_displayBlendedImage() {
 
     int frameHeight = static_cast<int>(frameDetails.height) / 2;
     int frameWidth = static_cast<int>(frameDetails.width);
+    int max_value_of_IR_pixel = (1 << m_ctrl->getbitCount()) - 1;
 
     m_irImage = cv::Mat(frameHeight, frameWidth, CV_16UC1, irData);
-    m_irImage.convertTo(m_irImage, CV_8U, 255.0 / m_ctrl->getRange());
+    m_irImage.convertTo(m_irImage, CV_8U, 255.0 / max_value_of_IR_pixel);
     flip(m_irImage, m_irImage, 1);
     cv::cvtColor(m_irImage, m_irImage, cv::COLOR_GRAY2RGB);
 

--- a/sdk/include/aditof/camera_definitions.h
+++ b/sdk/include/aditof/camera_definitions.h
@@ -59,6 +59,11 @@ struct CameraDetails {
      * @brief The range of the camera in mm for the operating mode
      */
     int range;
+
+    /**
+     * @brief The number of bits used for representing one pixel data.
+     */
+    int bitCount;
 };
 
 } // namespace aditof

--- a/sdk/src/camera_96tof1.cpp
+++ b/sdk/src/camera_96tof1.cpp
@@ -37,6 +37,8 @@ aditof::Status Camera96Tof1::initialize() {
         return status;
     }
 
+    m_details.bitCount = 12;
+
     LOG(INFO) << "Camera initialized";
 
     return Status::OK;


### PR DESCRIPTION
Instead of the range, we will use the max possible value of a pixel.
Because there are only 12 bits that are usable from 16, the maximal value = 4095.

Fixes: #176.

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>