### PR TITLE
Demo: Colored depth map values correction by using minimum range

### DIFF
--- a/bindings/open3D/showPointCloud/main.cpp
+++ b/bindings/open3D/showPointCloud/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
 
     aditof::CameraDetails cameraDetails;
     camera->getDetails(cameraDetails);
-    int camera_range = cameraDetails.range;
+    int camera_range = cameraDetails.rangeMax;
     int bitCount = cameraDetails.bitCount;
 
     const int smallSignalThreshold = 50;

--- a/bindings/opencv/dnn/main.cpp
+++ b/bindings/opencv/dnn/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
 
     aditof::CameraDetails cameraDetails;
     camera->getDetails(cameraDetails);
-    int cameraRange = cameraDetails.range;
+    int cameraRange = cameraDetails.maxDepth;
     int bitCount = cameraDetails.bitCount;
 
     aditof::Frame frame;

--- a/bindings/opencv/imshow/main.cpp
+++ b/bindings/opencv/imshow/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
 
     aditof::CameraDetails cameraDetails;
     camera->getDetails(cameraDetails);
-    int cameraRange = cameraDetails.range;
+    int cameraRange = cameraDetails.maxDepth;
     aditof::Frame frame;
 
     const int smallSignalThreshold = 50;

--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -53,7 +53,8 @@ PYBIND11_MODULE(aditofpython, m) {
         .def_readwrite("mode", &aditof::CameraDetails::mode)
         .def_readwrite("frameType", &aditof::CameraDetails::frameType)
         .def_readwrite("connection", &aditof::CameraDetails::connection)
-        .def_readwrite("range", &aditof::CameraDetails::range)
+        .def_readwrite("minDepth", &aditof::CameraDetails::minDepth)
+        .def_readwrite("maxDepth", &aditof::CameraDetails::maxDepth)
         .def_readwrite("bitCount", &aditof::CameraDetails::bitCount);
 
     // Helpers

--- a/bindings/python/examples/dnn/dnn.py
+++ b/bindings/python/examples/dnn/dnn.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     specifics.setNoiseReductionThreshold(smallSignalThreshold)
     specifics.enableNoiseReduction(True)
 
-    camera_range = camDetails.range
+    camera_range = camDetails.maxDepth
     bitCount = camDetails.bitCount
     frame = tof.Frame()
 

--- a/bindings/python/examples/showPointCloud/showPointCloud.py
+++ b/bindings/python/examples/showPointCloud/showPointCloud.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     specifics.setNoiseReductionThreshold(smallSignalThreshold)
     specifics.enableNoiseReduction(True)
 
-    camera_range = camDetails.range
+    camera_range = camDetails.maxDepth
     bitCount = camDetails.bitCount
     frame = tof.Frame()
 

--- a/examples/aditof-demo/aditofdemocontroller.cpp
+++ b/examples/aditof-demo/aditofdemocontroller.cpp
@@ -14,9 +14,7 @@ AdiTofDemoController::AdiTofDemoController()
         // Use the first camera that is found
         m_cameraInUse = 0;
         auto camera = m_cameras[static_cast<unsigned int>(m_cameraInUse)];
-
         camera->initialize();
-
         std::vector<std::string> frameTypes;
         camera->getAvailableFrameTypes(frameTypes);
         if (frameTypes.empty()) {
@@ -259,11 +257,18 @@ void AdiTofDemoController::captureFrames() {
     }
 }
 
-int AdiTofDemoController::getRange() const {
+int AdiTofDemoController::getRangeMax() const {
     aditof::CameraDetails cameraDetails;
     m_cameras[static_cast<unsigned int>(m_cameraInUse)]->getDetails(
         cameraDetails);
-    return cameraDetails.range;
+    return cameraDetails.maxDepth;
+}
+
+int AdiTofDemoController::getRangeMin() const {
+    aditof::CameraDetails cameraDetails;
+    m_cameras[static_cast<unsigned int>(m_cameraInUse)]->getDetails(
+        cameraDetails);
+    return cameraDetails.minDepth;
 }
 
 int AdiTofDemoController::getbitCount() const {

--- a/examples/aditof-demo/aditofdemocontroller.h
+++ b/examples/aditof-demo/aditofdemocontroller.h
@@ -46,7 +46,9 @@ class AdiTofDemoController {
 
     bool hasCamera() const;
 
-    int getRange() const;
+    int getRangeMax() const;
+
+    int getRangeMin() const;
 
     int getbitCount() const;
 

--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -171,6 +171,7 @@ void AdiTofDemoView::render() {
     int numberOfFrames = 0;
 
     std::string modes[3] = {"near", "medium", "far"};
+    int range_minValues[3] = {0, 390, 2000};
 
     char afe_temp_str[32] = "AFE TEMP:";
     char laser_temp_str[32] = "LASER TEMP:";
@@ -774,12 +775,18 @@ void AdiTofDemoView::_displayDepthImage() {
         int frameWidth = static_cast<int>(frameDetails.width);
 
         m_depthImage = cv::Mat(frameHeight, frameWidth, CV_16UC1, data);
+        cv::Mat m_distanceImage =
+            cv::Mat(frameHeight, frameWidth, CV_16UC1, data);
         cv::Point2d pointxy(320, 240);
         m_distanceVal = static_cast<int>(
-            m_distanceVal * 0.7 + m_depthImage.at<ushort>(pointxy) * 0.3);
+            m_distanceVal * 0.7 + m_distanceImage.at<ushort>(pointxy) * 0.3);
         char text[20];
         sprintf(text, "%dmm", m_distanceVal);
-        m_depthImage.convertTo(m_depthImage, CV_8U, 255.0 / m_ctrl->getRange());
+        m_depthImage.convertTo(
+            m_depthImage, CV_8U,
+            (255.0 / (m_ctrl->getRangeMax() - m_ctrl->getRangeMin())),
+            (-(255.0 / (m_ctrl->getRangeMax() - m_ctrl->getRangeMin())) *
+             m_ctrl->getRangeMin()));
         applyColorMap(m_depthImage, m_depthImage, cv::COLORMAP_RAINBOW);
         flip(m_depthImage, m_depthImage, 1);
         int color;
@@ -875,7 +882,11 @@ void AdiTofDemoView::_displayBlendedImage() {
     cv::cvtColor(m_irImage, m_irImage, cv::COLOR_GRAY2RGB);
 
     m_depthImage = cv::Mat(frameHeight, frameWidth, CV_16UC1, data);
-    m_depthImage.convertTo(m_depthImage, CV_8U, 255.0 / m_ctrl->getRange());
+    m_depthImage.convertTo(
+        m_depthImage, CV_8U,
+        (255.0 / (m_ctrl->getRangeMax() - m_ctrl->getRangeMin())),
+        (-(255.0 / (m_ctrl->getRangeMax() - m_ctrl->getRangeMin())) *
+         m_ctrl->getRangeMin()));
     flip(m_depthImage, m_depthImage, 1);
     applyColorMap(m_depthImage, m_depthImage, cv::COLORMAP_RAINBOW);
 

--- a/examples/aditof-demo/aditofdemoview.h
+++ b/examples/aditof-demo/aditofdemoview.h
@@ -47,6 +47,7 @@ class AdiTofDemoView {
 
     std::mutex m_imshowMutex;
     int m_waitKeyBarrier;
+
     std::condition_variable m_barrierCv;
     int m_distanceVal;
 

--- a/sdk/include/aditof/camera_definitions.h
+++ b/sdk/include/aditof/camera_definitions.h
@@ -56,9 +56,16 @@ struct CameraDetails {
     ConnectionType connection;
 
     /**
-     * @brief The range of the camera in mm for the operating mode
+     * @brief The maximum distance (in millimeters) the camera can measure in
+     * the current operating mode.
      */
-    int range;
+    int maxDepth;
+
+    /**
+     * @brief The minimum distance (in millimeters) the camera can measure in
+     * the current operating mode.
+     */
+    int minDepth;
 
     /**
      * @brief The number of bits used for representing one pixel data.

--- a/sdk/src/camera_96tof1.h
+++ b/sdk/src/camera_96tof1.h
@@ -36,6 +36,11 @@ class Camera96Tof1 : public aditof::Camera {
     std::shared_ptr<aditof::DeviceInterface> m_device;
     bool m_devStarted;
     Calibration m_calibration;
+    struct rangeStruct {
+        std::string mode;
+        int minDepth;
+        int maxDepth;
+    };
 
   public:
     friend class aditof::Camera96Tof1Specifics;


### PR DESCRIPTION
Added minimum extremity range in camera details.
Used the minimum extremity range to correct the values in colored depth map.

Solves #185 

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>