### PR TITLE
sdk: Add option to select the revision in camera specifics

### DIFF
--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -47,6 +47,10 @@ PYBIND11_MODULE(aditofpython, m) {
         .value("Ethernet", aditof::ConnectionType::ETHERNET)
         .value("local", aditof::ConnectionType::LOCAL);
 
+    py::enum_<aditof::Revision>(m, "Revision")
+        .value("RevB", aditof::Revision::RevB)
+        .value("RevC", aditof::Revision::RevC);
+
     py::class_<aditof::CameraDetails>(m, "CameraDetails")
         .def(py::init<>())
         .def_readwrite("cameraId", &aditof::CameraDetails::cameraId)
@@ -280,5 +284,9 @@ PYBIND11_MODULE(aditofpython, m) {
              &aditof::Camera96Tof1Specifics::setNoiseReductionThreshold,
              py::arg("threshold"))
         .def("noiseReductionThreshold",
-             &aditof::Camera96Tof1Specifics::noiseReductionThreshold);
+             &aditof::Camera96Tof1Specifics::noiseReductionThreshold)
+        .def("setCameraRevision",
+             &aditof::Camera96Tof1Specifics::setCameraRevision,
+             py::arg("revision"))
+        .def("getRevision", &aditof::Camera96Tof1Specifics::getRevision);
 }

--- a/bindings/python/examples/showPointCloud/showPointCloud.py
+++ b/bindings/python/examples/showPointCloud/showPointCloud.py
@@ -44,6 +44,9 @@ if __name__ == "__main__":
     if not status:
         print("cameras[0].setFrameType() failed with status:", status)
 
+    specifics = cameras[0].getCamera96Tof1Specifics()
+    specifics.setCameraRevision(tof.Revision.RevC)
+
     status = cameras[0].setMode(modes[ModesEnum.MODE_MEDIUM.value])
     if not status:
         print("cameras[0].setMode() failed with status: ", status)
@@ -54,7 +57,7 @@ if __name__ == "__main__":
         print("system.getDetails() failed with status: ", status)
 
     smallSignalThreshold = 50
-    specifics = cameras[0].getCamera96Tof1Specifics()
+
     specifics.setNoiseReductionThreshold(smallSignalThreshold)
     specifics.enableNoiseReduction(True)
 

--- a/examples/aditof-demo/aditofdemocontroller.cpp
+++ b/examples/aditof-demo/aditofdemocontroller.cpp
@@ -312,3 +312,27 @@ AdiTofDemoController::setNoiseReductionThreshold(uint16_t threshold) {
 
     return Status::GENERIC_ERROR;
 }
+
+aditof::Status
+AdiTofDemoController::setCameraRevision(const std::string &revision) {
+    using namespace aditof;
+
+    aditof::Status status;
+    if (m_cameraInUse < 0)
+        return Status::GENERIC_ERROR;
+
+    auto specifics =
+        m_cameras[static_cast<unsigned int>(m_cameraInUse)]->getSpecifics();
+    auto cam96tof1Specifics =
+        std::dynamic_pointer_cast<Camera96Tof1Specifics>(specifics);
+
+    if (revision.compare("RevB") == 0) {
+        status = cam96tof1Specifics->setCameraRevision(Revision::RevB);
+    } else if (revision.compare("RevC") == 0) {
+        status = cam96tof1Specifics->setCameraRevision(Revision::RevC);
+    } else {
+        status = Status::INVALID_ARGUMENT;
+    }
+
+    return status;
+}

--- a/examples/aditof-demo/aditofdemocontroller.h
+++ b/examples/aditof-demo/aditofdemocontroller.h
@@ -58,6 +58,8 @@ class AdiTofDemoController {
     aditof::Status enableNoiseReduction(bool en);
     aditof::Status setNoiseReductionThreshold(uint16_t threshold);
 
+    aditof::Status setCameraRevision(const std::string &revision);
+
   private:
     void captureFrames();
 

--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -115,6 +115,11 @@ void AdiTofDemoView::render() {
     bool ethModeChecked = false;
     int connectionCurrentValue = 4;
 
+    bool revBChecked = false;
+    bool revCChecked = true;
+    int revCurrentValue = 1; // 2 = RevB; 1 = RevC(default)
+    std::string revisions[2] = {"RevB", "RevC"};
+
     if (typeOfDevice.find(typeUSBDevice) != std::string::npos) {
         USBModeChecked = true;
     } else {
@@ -171,15 +176,15 @@ void AdiTofDemoView::render() {
     int numberOfFrames = 0;
 
     std::string modes[3] = {"near", "medium", "far"};
-    int range_minValues[3] = {0, 390, 2000};
 
     char afe_temp_str[32] = "AFE TEMP:";
     char laser_temp_str[32] = "LASER TEMP:";
     int temp_cnt = 0;
 
     while (true) {
+
         // Fill the frame with a nice color
-        cv::Mat frame = cv::Mat(530, 400, CV_8UC3);
+        cv::Mat frame = cv::Mat(550, 400, CV_8UC3);
 
         frame = cv::Scalar(49, 52, 49);
 
@@ -214,6 +219,32 @@ void AdiTofDemoView::render() {
             mediumLevelChecked = xorValue & (1 << 1);
             highLevelChecked = xorValue & 1;
             checkboxChanged = true;
+        }
+
+        cvui::beginColumn(frame, 50, 460);
+        cvui::space(10);
+        cvui::text("Revision: ", 0.6);
+        cvui::space(10);
+        cvui::beginRow(frame, 50, 495);
+        cvui::checkbox("RevB", &revBChecked);
+        cvui::space(10);
+        cvui::checkbox("RevC", &revCChecked);
+        cvui::endRow();
+        cvui::endColumn();
+
+        // Rev checkbox group
+        int btnGroupRev = revBChecked << 1 | revCChecked;
+        if (revCurrentValue != btnGroupRev) {
+            int xorValue = revCurrentValue ^ btnGroupRev;
+            revCurrentValue = xorValue;
+            revBChecked = xorValue & (1 << 1);
+            revCChecked = xorValue & 1;
+        }
+
+        if (revBChecked) {
+            m_ctrl->setCameraRevision(revisions[0]);
+        } else {
+            m_ctrl->setCameraRevision(revisions[1]);
         }
 
         // play button group
@@ -565,7 +596,7 @@ void AdiTofDemoView::render() {
         }
 #endif
         if (displayFps && (captureEnabled || captureBlendedEnabled)) {
-            cvui::text(frame, 350, 510, "FPS:" + std::to_string(displayFps));
+            cvui::text(frame, 350, 520, "FPS:" + std::to_string(displayFps));
         }
 
         if (captureEnabled || captureBlendedEnabled) {
@@ -575,8 +606,8 @@ void AdiTofDemoView::render() {
                 sprintf(afe_temp_str, "AFE TEMP: %.1f", temp.first);
                 sprintf(laser_temp_str, "LASER TEMP: %.1f", temp.second);
             }
-            cvui::text(frame, 20, 510, afe_temp_str);
-            cvui::text(frame, 180, 510, laser_temp_str);
+            cvui::text(frame, 20, 520, afe_temp_str);
+            cvui::text(frame, 180, 520, laser_temp_str);
         }
 
         if ((captureEnabled || captureBlendedEnabled) && !playbackEnabled) {

--- a/sdk/include/aditof/camera_96tof1_specifics.h
+++ b/sdk/include/aditof/camera_96tof1_specifics.h
@@ -11,6 +11,12 @@ class Camera96Tof1;
 namespace aditof {
 
 /**
+ * @enum Revision
+ * @brief Enumerates camera revisions
+ */
+enum class Revision { RevB, RevC };
+
+/**
  * @class Camera96Tof1Specifics
  * @brief Implements the extened API that is specific for the 96 TOF1 camera.
  */
@@ -48,6 +54,18 @@ class SDK_API Camera96Tof1Specifics : public CameraSpecifics {
      */
     uint16_t noiseReductionThreshold() const;
 
+    /**
+     * @brief Sets the camera revision type.
+     * @return Status
+     */
+    Status setCameraRevision(Revision revision);
+
+    /**
+     * @brief Returns the current camera revision type.
+     * @return Revision
+     */
+    Revision getRevision() const;
+
   private:
     Status setTresholdAndEnable(uint16_t treshold, bool en);
 
@@ -55,6 +73,7 @@ class SDK_API Camera96Tof1Specifics : public CameraSpecifics {
     Camera96Tof1 *m_camera;
     bool m_noiseReductionOn;
     uint16_t m_noiseReductionThreshold;
+    Revision m_revision;
 };
 
 } // namespace aditof

--- a/sdk/src/camera_96tof1.h
+++ b/sdk/src/camera_96tof1.h
@@ -7,7 +7,6 @@
 
 #include <aditof/camera.h>
 #include <aditof/camera_96tof1_specifics.h>
-
 class Camera96Tof1 : public aditof::Camera {
   public:
     Camera96Tof1(std::unique_ptr<aditof::DeviceInterface> device);
@@ -36,11 +35,6 @@ class Camera96Tof1 : public aditof::Camera {
     std::shared_ptr<aditof::DeviceInterface> m_device;
     bool m_devStarted;
     Calibration m_calibration;
-    struct rangeStruct {
-        std::string mode;
-        int minDepth;
-        int maxDepth;
-    };
 
   public:
     friend class aditof::Camera96Tof1Specifics;

--- a/sdk/src/camera_96tof1_specifics.cpp
+++ b/sdk/src/camera_96tof1_specifics.cpp
@@ -8,7 +8,6 @@ using namespace aditof;
 Camera96Tof1Specifics::Camera96Tof1Specifics(Camera *camera)
     : m_camera(dynamic_cast<Camera96Tof1 *>(camera)), m_noiseReductionOn(false),
       m_noiseReductionThreshold(0) {
-
     if (!m_camera) {
         LOG(ERROR) << "Cannot cast camera to a Camera96Tof1";
     }
@@ -38,6 +37,13 @@ Status Camera96Tof1Specifics::setNoiseReductionThreshold(uint16_t threshold) {
 
     return status;
 }
+
+Status Camera96Tof1Specifics::setCameraRevision(Revision revision) {
+    m_revision = revision;
+    return Status::OK;
+}
+
+Revision Camera96Tof1Specifics::getRevision() const { return m_revision; }
 
 uint16_t Camera96Tof1Specifics::noiseReductionThreshold() const {
     return m_noiseReductionThreshold;


### PR DESCRIPTION
Revision can be selected and the value for the MaxDepth changes accordingly.
Added example of usage in the demo application.

Solves #186.

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>