### PR TITLE
Open3d: fixed depth construction with ranges.

### DIFF
--- a/bindings/open3D/aditof_open3d.h
+++ b/bindings/open3D/aditof_open3d.h
@@ -8,8 +8,8 @@
 using namespace open3d;
 
 namespace aditof {
-Status fromFrameToDepthImg(Frame &frame, int camera_range,
-                           geometry::Image &image) {
+Status fromFrameToDepthImg(Frame &frame, int camera_rangeMin,
+                           int camera_rangeMax, geometry::Image &image) {
     FrameDetails frameDetails;
     frame.getDetails(frameDetails);
 
@@ -27,8 +27,10 @@ Status fromFrameToDepthImg(Frame &frame, int camera_range,
     for (int i = 0; i < frameHeight * frameWidth; i++) {
         uint8_t *p =
             static_cast<uint8_t *>(image.data_.data() + i * sizeof(uint8_t));
-        uint16_t value = *(depthData + i) * 255.0 / camera_range;
-        *p = static_cast<uint8_t>(value <= 255 ? value : 255);
+        uint16_t value =
+            *(depthData + i) * 255.0 / (camera_rangeMax - camera_rangeMin) -
+            ((255.0 / (camera_rangeMax - camera_rangeMin)) * camera_rangeMin);
+        *p = static_cast<uint8_t>(value <= 255 ? value : 0);
         p++;
     }
 

--- a/bindings/open3D/showPointCloud/main.cpp
+++ b/bindings/open3D/showPointCloud/main.cpp
@@ -70,7 +70,8 @@ int main(int argc, char *argv[]) {
 
     aditof::CameraDetails cameraDetails;
     camera->getDetails(cameraDetails);
-    int camera_range = cameraDetails.rangeMax;
+    int camera_rangeMax = cameraDetails.maxDepth;
+    int camera_rangeMin = cameraDetails.minDepth;
     int bitCount = cameraDetails.bitCount;
 
     const int smallSignalThreshold = 50;
@@ -125,7 +126,8 @@ int main(int argc, char *argv[]) {
             return 0;
         }
         geometry::Image depth_image;
-        status = fromFrameToDepthImg(frame, camera_range, depth_image);
+        status = fromFrameToDepthImg(frame, camera_rangeMin, camera_rangeMax,
+                                     depth_image);
         if (status != Status::OK) {
             LOG(ERROR) << "Could not convert from frame to Image!";
         }
@@ -182,7 +184,7 @@ int main(int argc, char *argv[]) {
         depth_vis.UpdateRender();
 
         auto rgbd_ptr = geometry::RGBDImage::CreateFromColorAndDepth(
-            color_image, depth_image, 1.0, 3.0, false);
+            color_image, depth_image, 1000.0, 3.0, false);
         if (!pointcloud_ptr) {
             pointcloud_ptr =
                 geometry::PointCloud::CreateFromRGBDImage(*rgbd_ptr, intrinsic);


### PR DESCRIPTION
Added the usage of Minimum depth range in the construction of the depth image.

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>