### PR TITLE
sdk: Fix buffer overrun and memory leak in device enumerator

### DIFF
--- a/sdk/src/target/dragonboard/device_enumerator_dragonboard.cpp
+++ b/sdk/src/target/dragonboard/device_enumerator_dragonboard.cpp
@@ -36,9 +36,11 @@ aditof::Status findDevicePathsAtMedia(const std::string &media,
         size++;
     }
     pclose(fp);
+    buf[size] = '\0';
 
     /* Get the list of entities from output buffer */
     string str(buf);
+    free(buf);
     vector<string> entities;
     size_t pos = str.find("entity");
     while (pos != string::npos) {


### PR DESCRIPTION
Bug is in the dragonboard implementation.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>