### PR TITLE
sdk: Add missing include. Fixes compile error on MSVC.

### DIFF
--- a/sdk/src/system_impl.h
+++ b/sdk/src/system_impl.h
@@ -4,6 +4,7 @@
 #include <aditof/status_definitions.h>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace aditof {


### PR DESCRIPTION
Solves #207 