### PR TITLE
examples/aditof_demo: Apply threshold when enabling small signal removal

### DIFF
--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -644,6 +644,10 @@ void AdiTofDemoView::render() {
         m_smallSignal = m_crtSmallSignalState;
         if (smallSignalChanged) {
             aditof::Status ret = m_ctrl->enableNoiseReduction(m_smallSignal);
+            if (ret == aditof::Status::OK) {
+                m_ctrl->setNoiseReductionThreshold(
+                    static_cast<uint16_t>(smallSignalThreshold));
+            }
 
             if (ret == aditof::Status::GENERIC_ERROR) {
                 status = "No cameras connected!";


### PR DESCRIPTION
Right after startup of the demo application if one enables the small signal removal, the feature will be enabled with a default threshold of 0 instead of default value set in UI which is 50.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>