### PR TITLE
Demo: noise reduction issue

### DIFF
--- a/examples/aditof-demo/aditofdemoview.h
+++ b/examples/aditof-demo/aditofdemoview.h
@@ -51,7 +51,6 @@ class AdiTofDemoView {
     std::condition_variable m_barrierCv;
     int m_distanceVal;
 
-    bool m_smallSignal;
     bool m_crtSmallSignalState;
 };
 


### PR DESCRIPTION
Disabled the state of noise reduction when switching between modes.
Simplified the code, to use only 2 variables, not 3.

Solves #183 

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>
