### PR TITLE
Demo: far mode does not support noise reduction.

### DIFF
--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -269,6 +269,7 @@ void AdiTofDemoView::render() {
             int selectedMode =
                 (2 - static_cast<int>(std::log2(modeCurrentValue)));
             m_ctrl->setMode(modes[selectedMode]);
+            status = "Mode set: " + modes[selectedMode];
             m_crtSmallSignalState = false;
         }
 
@@ -645,9 +646,11 @@ void AdiTofDemoView::render() {
             if (ret == aditof::Status::OK) {
                 m_ctrl->setNoiseReductionThreshold(
                     static_cast<uint16_t>(smallSignalThreshold));
-            }
-            if (ret == aditof::Status::GENERIC_ERROR) {
+            } else if (ret == aditof::Status::GENERIC_ERROR) {
                 status = "No cameras connected!";
+                m_crtSmallSignalState = false;
+            } else if (ret == aditof::Status::UNAVAILABLE) {
+                status = "Far mode does not support noise reduction";
                 m_crtSmallSignalState = false;
             }
             lastSmallSignalState = m_crtSmallSignalState;
@@ -660,6 +663,8 @@ void AdiTofDemoView::render() {
 
             if (noiseReductionStatus == aditof::Status::GENERIC_ERROR) {
                 status = "No cameras connected!";
+            } else if (noiseReductionStatus == aditof::Status::UNAVAILABLE) {
+                status = "Far mode does not support noise reduction";
             }
         }
 

--- a/sdk/include/aditof/status_definitions.h
+++ b/sdk/include/aditof/status_definitions.h
@@ -15,6 +15,7 @@ enum class Status {
     BUSY,             //!< Device or resource is busy
     UNREACHABLE,      //!< Device or resource is unreachable
     INVALID_ARGUMENT, //!< Invalid arguments provided
+    UNAVAILABLE,      //!< The requested action or resource is unavailable
     GENERIC_ERROR     //!< An error occured but there are no details available.
 };
 

--- a/sdk/src/camera_96tof1_specifics.cpp
+++ b/sdk/src/camera_96tof1_specifics.cpp
@@ -50,6 +50,13 @@ uint16_t Camera96Tof1Specifics::noiseReductionThreshold() const {
 }
 
 Status Camera96Tof1Specifics::setTresholdAndEnable(uint16_t treshold, bool en) {
+    aditof::CameraDetails cameraDetails;
+    m_camera->getDetails(cameraDetails);
+    if (cameraDetails.mode.compare("far") == 0) {
+        LOG(WARNING) << "Far mode does not support noise reduction!";
+        return Status::UNAVAILABLE;
+    }
+
     const size_t REGS_CNT = 5;
     uint16_t afeRegsAddr[REGS_CNT] = {0x4001, 0x7c22, 0xc34a, 0x4001, 0x7c22};
     uint16_t afeRegsVal[REGS_CNT] = {0x0006, 0x0004, 0, 0x0007, 0x0004};


### PR DESCRIPTION
Because of hardware limitations, noise reduction does not work in far mode.
This is disabled from extended camera API.

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>