### PR TITLE
bindings: matlab: fix adaptor build

### DIFF
--- a/bindings/matlab/source_adaptor.h
+++ b/bindings/matlab/source_adaptor.h
@@ -176,7 +176,7 @@ class SourceAdaptor : public imaqkit::IAdaptor {
 
     void setMode(int16_t mode);
 
-    int getCurrentHwRange();
+    std::pair<int, int> getCurrentHwRange() const;
 
     int getCurrentBitCount();
 


### PR DESCRIPTION
Build was failing due to a change in the structure of the camera details. Now the depth image should be converted to pixels according to the minimum and maximum depth value it can measure in the desired mode. 

Fixes issue: #237  

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>