### PR TITLE
Provide CI for ROS package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 matrix:
   include:
     - stage: Build
-      
+
       # Dragonboard
       dist: xenial
       name: Dragonboard
@@ -39,13 +39,20 @@ matrix:
       addons: { apt: { packages: ["clang-8", "cmake"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-8"] } }
 
       #GCC 7
-    - env: COMPILER=g++-7 
+    - env: COMPILER=g++-7
       addons: { apt: { packages: ["g++-7", "cmake"], sources: ["ubuntu-toolchain-r-test"] } }
 
       #GCC 8
     - env: COMPILER=g++-8
            CMAKE_OPTIONS="-DWITH_EXAMPLES=on -DWITH_PYTHON=on -DWITH_OPENCV=on"
       addons: { apt: { packages: ["g++-8", "cmake"], sources: ["ubuntu-toolchain-r-test"] } }
+
+      #ROS
+    - dist: bionic
+      name: "Bionic Melodic"
+      env: BUILD_TYPE=ros
+           CMAKE_OPTIONS="-DWITH_EXAMPLES=off -DWITH_ROS=on"
+           ROS_DISTRO=melodic
 
     # TODO: enable MacOS builds again when the sdk will support MacOS
     #   #MacOS Mojave
@@ -78,7 +85,10 @@ matrix:
       dist: xenial
       env: BUILD_TYPE=deploy_doxygen
       addons: { apt: { packages: ["cmake", "graphviz"] } }
-      
+
+before_install:
+  - if [[ "${ROS_DISTRO}" != "" ]]; then ./ci/travis/ros_install.sh ; fi
+
 install:
   ############################################################################
   # Setup used compiler and make sure to override CXX env variable.
@@ -129,6 +139,13 @@ before_script:
     if [[ "$BUILD_TYPE" == "" ]]; then
       pushd "${TRAVIS_BUILD_DIR}"
       mkdir build && cd build && cmake .. ${CMAKE_OPTIONS} -DPYTHON_EXECUTABLE=${PYTHON} -DCMAKE_PREFIX_PATH="${DEPS_DIR}/installed/glog;${DEPS_DIR}/installed/protobuf;${DEPS_DIR}/installed/websockets;${DEPS_DIR}/installed/opencv;";
+      popd
+    fi
+
+  - |
+    if [[ "$BUILD_TYPE" == "ros" ]]; then
+      pushd "${TRAVIS_BUILD_DIR}"
+      mkdir build && cd build && cmake .. ${CMAKE_OPTIONS} -DCMAKE_PREFIX_PATH="${DEPS_DIR}/installed/glog;${DEPS_DIR}/installed/protobuf;${DEPS_DIR}/installed/websockets;";
       popd
     fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(WITH_PYTHON "Build python bindings?" OFF)
 option(WITH_OPENCV "Build opencv bindings?" OFF)
 option(WITH_MATLAB "Build matlab bindings?" OFF)
 option(WITH_OPEN3D "Build open3d bindings?" OFF)
+option(WITH_ROS "Build ros bindings?" OFF)
 
 add_subdirectory(sdk)
 add_subdirectory(apps)
@@ -44,6 +45,9 @@ if (WITH_MATLAB)
 endif()
 if (WITH_OPEN3D)
         add_subdirectory(bindings/open3D)
+endif()
+if (WITH_ROS)
+        add_subdirectory(bindings/ros)
 endif()
 
 ############################### Installer #######################################

--- a/bindings/ros/CMakeLists.txt
+++ b/bindings/ros/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+if(UNIX)
+
+  # set variables
+  set(CATKIN_WS "${CMAKE_BINARY_DIR}/catkin_ws")
+  set(ROS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  # create and run ROS setup script
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ros_setup.bash
+                 ${CMAKE_BINARY_DIR}/tmp/ros_setup.bash)
+  file(
+    COPY ${CMAKE_BINARY_DIR}/tmp/ros_setup.bash
+    DESTINATION ${CMAKE_BINARY_DIR}
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+
+  add_custom_target(aditof_ros_package)
+  string(CONCAT OLD_CMAKE_INSTALL_PREFIX "\"${CMAKE_INSTALL_PREFIX}\"")
+  string(CONCAT OLD_CMAKE_PREFIX_PATH "\"${CMAKE_PREFIX_PATH}\"")
+  add_custom_command(
+    TARGET aditof_ros_package
+    COMMAND ${CMAKE_BINARY_DIR}/ros_setup.bash "${OLD_CMAKE_INSTALL_PREFIX}"
+            "${OLD_CMAKE_PREFIX_PATH}" ${VERSION} DEPENDS aditof)
+endif()

--- a/bindings/ros/aditof_roscpp/CMakeLists.txt
+++ b/bindings/ros/aditof_roscpp/CMakeLists.txt
@@ -1,31 +1,30 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(aditof_roscpp)
 
-option(WITH_EXAMPLES "Build examples?" ON)
+option(WITH_ROS_EXAMPLES "Build ROS examples" ON)
 
-## Find catkin macros and libraries
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  sensor_msgs
-)
-find_package(aditof REQUIRED)
+list(APPEND CMAKE_PREFIX_PATH ${ADITOF_CMAKE_INSTALL_PREFIX} ${ADITOF_CMAKE_PREFIX_PATH})
 
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS roscpp sensor_msgs
-)
+# Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs)
+find_package(aditof ${VERSION} REQUIRED)
 
-include_directories(include/${PROJECT_NAME} ${catkin_INCLUDE_DIRS})
+include_directories(include/${PROJECT_NAME} ${catkin_INCLUDE_DIRS} ${aditof_INCLUDE_DIRS})
 
-if (WITH_EXAMPLES)
-    find_package(catkin REQUIRED COMPONENTS
-      rviz
-    )
+catkin_package(INCLUDE_DIRS include CATKIN_DEPENDS roscpp sensor_msgs DEPENDS aditof )
 
-    file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
-    add_executable(aditof_rviz_pcl ${CMAKE_CURRENT_SOURCE_DIR}/src/examples/rviz_pointcloud.cpp ${SOURCES})
-    target_sources(aditof_rviz_pcl INTERFACE ${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME})
-    target_link_libraries(aditof_rviz_pcl ${aditof_LIBRARIES})
-    target_link_libraries(aditof_rviz_pcl ${catkin_LIBRARIES})
+if(WITH_ROS_EXAMPLES)
+  find_package(catkin REQUIRED COMPONENTS rviz)
+
+  file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+
+  add_executable(
+    aditof_rviz_pcl ${CMAKE_CURRENT_SOURCE_DIR}/src/examples/rviz_pointcloud.cpp
+                    ${SOURCES})
+  target_sources(aditof_rviz_pcl
+                 INTERFACE ${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME})
+  target_link_libraries(aditof_rviz_pcl aditof::aditof)
+  target_link_libraries(aditof_rviz_pcl ${catkin_LIBRARIES})
+
 endif()

--- a/bindings/ros/ros_setup.bash
+++ b/bindings/ros/ros_setup.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DISTRO_CODENAME=$( (lsb_release -sc || . /etc/os-release; echo ${VERSION_CODENAME} ) 2>/dev/null)
+
+#determine ROS distribution
+if [ $DISTRO_CODENAME = "bionic" ]
+then
+	ROS_DISTRO="melodic"
+fi
+
+mkdir -p ${CATKIN_WS}/src
+cd ${CATKIN_WS}/src
+ln -sf ${ROS_SRC_DIR}/aditof_roscpp/ .
+
+cd ${CATKIN_WS}
+source /opt/ros/$ROS_DISTRO/setup.sh
+
+#we have to save the old value of CMAKE_INSTALL_PREFIX in another variable
+#because after running the setup.sh script, the variable will be reassigned
+catkin_make -DADITOF_CMAKE_INSTALL_PREFIX=$1 -DADITOF_CMAKE_PREFIX_PATH=$2

--- a/ci/travis/deps.sh
+++ b/ci/travis/deps.sh
@@ -36,4 +36,11 @@ deps_raspberrypi3() {
     pull_docker ${DOCKER}
 }
 
+deps_ros() {
+    get_deps_source_code ${DEPS_DIR}
+    build_and_install_glog "${DEPS_DIR}/glog" "${DEPS_DIR}/installed/glog"
+    build_and_install_protobuf "${DEPS_DIR}/protobuf" "${DEPS_DIR}/installed/protobuf"
+    build_and_install_websockets "${DEPS_DIR}/libwebsockets" "${DEPS_DIR}/installed/websockets"
+}
+
 deps_${BUILD_TYPE:-default}

--- a/ci/travis/ros_install.sh
+++ b/ci/travis/ros_install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu ${TRAVIS_DIST} main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+if [[ "{$ROS_DISTRO}"  = "melodic" ]]
+then
+  sudo apt update -qq
+  sudo apt install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-rviz
+else
+  sudo apt-get update -qq
+  sudo apt-get install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-rviz
+fi
+sudo rosdep init
+rosdep update

--- a/ci/travis/run_build.sh
+++ b/ci/travis/run_build.sh
@@ -21,7 +21,7 @@ build_clang_format() {
 
 build_deploy_doxygen() {
     pushd "${TRAVIS_BUILD_DIR}/doc"
-    mkdir build && cd build && cmake .. 
+    mkdir build && cd build && cmake ..
     check_doxygen
     deploy_doxygen
     popd
@@ -33,6 +33,14 @@ build_dragonboard() {
 
 build_raspberrypi3() {
     run_docker ${DOCKER} /aditof_sdk/ci/travis/inside_docker.sh -DRASPBERRYPI=TRUE
+}
+
+build_ros(){
+    pushd "${TRAVIS_BUILD_DIR}"
+    cd build
+    sudo cmake --build . --target install
+    cmake --build . --target aditof_ros_package
+    popd
 }
 
 build_${BUILD_TYPE:-default}


### PR DESCRIPTION
Added two more jobs in travis.yml file, for the latest ROS distributions.
Building the ROS package is enabled by setting a cmake parameter, similarly to the other bindings.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>