### PR TITLE
.clang-format: don't reflow comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,7 +92,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-ReflowComments:  true
+ReflowComments:  false
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false


### PR DESCRIPTION
If comments break the 80 chars per line rule, don't reflow them. This is
the case of the license headers in all files as they currently take more
than 80 chars on some lines.

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>