### PR TITLE
bindings: opencv: properly identify opencv version 2

### DIFF
--- a/bindings/opencv/CMakeLists.txt
+++ b/bindings/opencv/CMakeLists.txt
@@ -13,7 +13,11 @@ if(OPENCV_FOUND OR
    OPENCV_CORE_FOUND) # we check for this because the OpenCVConfig.cmake(v2.4.9.1) used on dragonboards fails to set OPENCV_FOUND
     if(OpenCV_VERSION VERSION_LESS "3.4.1")
         message(WARNING "The dnn example is only available for OpenCV version >= 3.4.1! This example won't be built!")
-        add_definitions(-DOPENCV2)
+
+        if(OpenCV_VERSION VERSION_LESS "3.0.0")
+            message(STATUS "USING OPENCV Version 2")
+            add_definitions(-DOPENCV2)
+        endif(OpenCV_VERSION VERSION_LESS "3.0.0")
 
         if(WIN32)
             include(FindOpenSSL)


### PR DESCRIPTION
The define for opencv version 2 was set for all versions less than 3.4.1. The correct define should be set only for versions less than 3.0.0

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>