### PR TITLE
Added udev-rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ if (WITH_ROS)
         add_subdirectory(bindings/ros)
 endif()
 
+############################### Install udev rules #######################################
+include (${CMAKE_SOURCE_DIR}/cmake/udev-rules-install.cmake)
+
 ############################### Installer #######################################
 configure_file(cmake/aditof-setup.iss.cmakein ${CMAKE_CURRENT_BINARY_DIR}/aditof-setup.iss @ONLY)
 

--- a/cmake/udev-rules-install.cmake
+++ b/cmake/udev-rules-install.cmake
@@ -1,0 +1,14 @@
+set(UDEV_RULES_PATH "/etc/udev/rules.d" CACHE STRING "Target directory for udev rules installation.")
+if(DRAGONBOARD)
+    set(ADITOF_UDEV_RULES "${CMAKE_SOURCE_DIR}/utils/dragonboard/53-aditofsdkdragonboard.rules")  
+elseif(RASPBERRYPI)
+    set(ADITOF_UDEV_RULES "${CMAKE_SOURCE_DIR}/utils/raspberrypi/53-aditofsdkraspberrypi.rules")
+
+elseif(JETSON)
+    set(ADITOF_UDEV_RULES "${CMAKE_SOURCE_DIR}/utils/jetson/53-aditofsdkjetson.rules")
+endif()
+add_custom_target(install-udev-rules
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ADITOF_UDEV_RULES} ${UDEV_RULES_PATH}
+    COMMAND udevadm control --reload-rules
+    COMMAND udevadm trigger
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/scripts/dragonboard410c/setup.sh
+++ b/scripts/dragonboard410c/setup.sh
@@ -21,6 +21,8 @@ print_help() {
         echo "        Build and install the minimum required version of opencv for the dnn example (3.4.1)"
         echo "-op|--opencvpath"
         echo "        Path to opencv installation "
+        echo "-ur|--udevrules"
+        echo "        Install udev rules for devices permissions"
         echo ""
 }
 
@@ -91,6 +93,10 @@ setup() {
                 opencv_path=$2
                 shift # next argument
                 shift # next value
+                ;;
+                -ur|--udevrules)
+                udev_rules="True"
+                shift # next argument
                 ;;
                 *)    # unknown option
                 POSITIONAL+=("$1") # save it in an array for later
@@ -166,6 +172,10 @@ setup() {
         pushd "${build_dir}"
         cmake "${source_dir}" ${CMAKE_OPTIONS} -DCMAKE_PREFIX_PATH="${PREFIX_PATH}"
         make
+		
+        if [[ "${udev_rules}" == "True" ]]; then
+             sudo make install-udev-rules
+        fi
 
 }
 

--- a/scripts/jetson/setup.sh
+++ b/scripts/jetson/setup.sh
@@ -24,6 +24,8 @@ print_help() {
         echo "        Build and install the minimum required version of opencv for the dnn example (3.4.1)"
         echo "-op|--opencvpath"
         echo "        Path to opencv installation "
+        echo "-ur|--udevrules"
+        echo "        Install udev rules for devices permissions"
         echo ""
 }
 
@@ -102,6 +104,10 @@ setup() {
                 shift # next argument
                 shift # next value
                 ;;
+                -ur|--udevrules)
+                udev_rules="True"
+                shift # next argument
+                ;;
                 *)    # unknown option
                 POSITIONAL+=("$1") # save it in an array for later
                 shift # past argument
@@ -176,6 +182,10 @@ setup() {
         pushd "${build_dir}"
         cmake "${source_dir}" ${CMAKE_OPTIONS} -DCMAKE_PREFIX_PATH="${PREFIX_PATH}"
         make -j ${NUM_JOBS}
+		
+        if [[ "${udev_rules}" == "True" ]]; then
+             sudo make install-udev-rules
+        fi
 }
 
 setup $@

--- a/scripts/raspberrypi3/setup.sh
+++ b/scripts/raspberrypi3/setup.sh
@@ -24,6 +24,8 @@ print_help() {
         echo "        Build and install the minimum required version of opencv for the dnn example (3.4.1)"
         echo "-op|--opencvpath"
         echo "        Path to opencv installation "
+        echo "-ur|--udevrules"
+        echo "        Install udev rules for devices permissions"
         echo ""
 }
 
@@ -102,6 +104,10 @@ setup() {
                 shift # next argument
                 shift # next value
                 ;;
+                -ur|--udevrules)
+                udev_rules="True"
+                shift # next argument
+                ;;
                 *)    # unknown option
                 POSITIONAL+=("$1") # save it in an array for later
                 shift # past argument
@@ -176,6 +182,10 @@ setup() {
         pushd "${build_dir}"
         cmake "${source_dir}" ${CMAKE_OPTIONS} -DCMAKE_PREFIX_PATH="${PREFIX_PATH}"
         make -j ${NUM_JOBS}
+		
+        if [[ "${udev_rules}" == "True" ]]; then
+             sudo make install-udev-rules
+        fi
 }
 
 setup $@

--- a/utils/dragonboard/53-aditofsdkdragonboard.rules
+++ b/utils/dragonboard/53-aditofsdkdragonboard.rules
@@ -1,0 +1,6 @@
+# allow read/write access to the eeprom and the temperature sensor for DragonBoard
+
+SUBSYSTEM=="i2c", 
+RUN+="/bin/chown root:plugdev /sys/bus/i2c/devices/0-0056/eeprom", 
+RUN+="/bin/chmod 0060 /sys/bus/i2c/devices/0-0056/eeprom", 
+RUN+="/bin/chmod 666 /dev/i2c-1"

--- a/utils/dragonboard/readme.md
+++ b/utils/dragonboard/readme.md
@@ -8,6 +8,7 @@ This directory contains different utilities may be needed on the Dragonbard.
 | --------- | -------------- |
 | config_pipe.sh | Configures the video data pipeline coming from the camera |
 | config_pipe.service | A 'systemd' startup script that executes config-pipe.sh when linaro boots |
+| 53-aditofsdkdragonboard.rules | Allows read/write access to the eeprom and the temperature sensor |
 
 To configure config-pipe.sh to be executed automatically on boot:
 

--- a/utils/jetson/53-aditofsdkjetson.rules
+++ b/utils/jetson/53-aditofsdkjetson.rules
@@ -1,0 +1,6 @@
+# allow read/write access to the eeprom and the temperature sensor for Jetson
+
+SUBSYSTEM=="i2c", 
+RUN+="/bin/chown root:plugdev /sys/bus/i2c/devices/6-0056/eeprom", 
+RUN+="/bin/chmod 0060 /sys/bus/i2c/devices/6-0056/eeprom",
+RUN+="/bin/chmod 666 /dev/i2c-6"

--- a/utils/jetson/readme.md
+++ b/utils/jetson/readme.md
@@ -1,0 +1,9 @@
+# Utilities for Jetson
+
+This directory contains different utilities may be needed on the Jetson.
+
+#### List of Utilities
+
+| Name | Description |
+| --------- | -------------- |
+| 53-aditofsdkjetson.rules | Allows read/write access to the eeprom and the temperature sensor |

--- a/utils/raspberrypi/53-aditofsdkraspberrypi.rules
+++ b/utils/raspberrypi/53-aditofsdkraspberrypi.rules
@@ -1,0 +1,9 @@
+# allow read/write access to the eeprom and the temperature sensor RaspberryPi
+
+SUBSYSTEM=="i2c", 
+RUN+="/bin/chown root:plugdev /sys/bus/i2c/devices/0-0056/eeprom", 
+RUN+="/bin/chmod 0060 /sys/bus/i2c/devices/0-0056/eeprom", 
+RUN+="/bin/chown root:plugdev /sys/bus/i2c/devices/1-0056/eeprom", 
+RUN+="/bin/chmod 0060 /sys/bus/i2c/devices/1-0056/eeprom",
+RUN+="/bin/chmod 666 /dev/i2c-0",
+RUN+="/bin/chmod 666 /dev/i2c-1"

--- a/utils/raspberrypi/readme.md
+++ b/utils/raspberrypi/readme.md
@@ -7,6 +7,7 @@ This directory contains different utilities that may be needed on the Raspberry 
 | Name | Description |
 | --------- | -------------- |
 | tof-server.service | A 'systemd' startup script that starts the Time of Flight server when raspbian boots |
+| 53-aditofsdkraspberrypi.rules | Allows read/write access to the eeprom and the temperature sensor |
 
 To enable the service:
 


### PR DESCRIPTION
Added udev-rules for eeprom access, for Dragonboard, Raspberrypi, Jetson.

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>

Solves #235 