### PR TITLE
bindings/open3d: Update README with options to build Open3D

### DIFF
--- a/bindings/open3D/readme.md
+++ b/bindings/open3D/readme.md
@@ -4,6 +4,12 @@
 The SDK provides bindings for Open3D through the helper methods defined in aditof_open3d.h, which provide a way to convert from the `aditof::Frame` data structure to `open3d::geometry::Image`.
 
 ### Instalation
+If you build open3D from source, make sure to enable option `GLIBCXX_USE_CXX11_ABI` when running cmake.
+For example:
+```
+cmake -DGLIBCXX_USE_CXX11_ABI=ON
+```
+
 To install open3D go to: [Open3D](http://www.open3d.org/docs/release/tutorial/C++/cplusplus_interface.html)
 
 #### Directory Structure


### PR DESCRIPTION
When building Open3D (v0.9.0.0) from source, the ABI for C++11 is disabled by default. And this perpetuates (as compiler flags) to the showPointCloud example and the SDK that make use of C++11 features, making them to not work properly or even not compile.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>