### PR TITLE
bindings: ros: Fix the depth data processing to obtain the z coordinate

### DIFF
--- a/bindings/ros/aditof_roscpp/src/pointcloud2_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/pointcloud2_msg.cpp
@@ -81,8 +81,16 @@ void PointCloud2Msg::setDataMembers(const std::shared_ptr<Camera> &camera,
             int index = i * msg.width + j;
             uint16_t depth = frameData[index];
 
+            //angle between camera's principal axis and the pixel that is being processed
+            double tanXAngle = (x0 - j) / fx;
+            double tanYAngle = (y0 - i) / fy;
+
+            double depth_scale =
+                sqrt(1 + tanXAngle * tanXAngle + tanYAngle * tanYAngle);
+            float z = static_cast<float>(depth / depth_scale);
+
             // rviz expects the data in metres
-            float z = depth / 1000.0f;
+            z /= 1000.0f;
 
             *iter_x = z * (j - x0) / fx;
             *iter_y = z * (i - y0) / fy;


### PR DESCRIPTION
In order to obtain the z coordinate, we need to perform computations on the depth value

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>