### PR TITLE
bindings: ros: Code refactor for frame-based message

### DIFF
--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_sensor_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_sensor_msg.h
@@ -38,8 +38,8 @@
 class AditofSensorMsg {
   public:
     virtual ~AditofSensorMsg() = default;
-    virtual void
-    FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera) = 0;
+    virtual void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
+                                aditof::Frame *frame) = 0;
     virtual void publishMsg(const ros::Publisher &pub) = 0;
 };
 

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
@@ -34,12 +34,16 @@
 
 #include <aditof/camera.h>
 
-std::shared_ptr<aditof::Camera> initCameraEthernet(int argc, char **argv);
-
+std::shared_ptr<aditof::Camera> initCamera(int argc, char **argv);
+void setFrameType(const std::shared_ptr<aditof::Camera> &camera,
+                  const std::string &type);
+void setMode(const std::shared_ptr<aditof::Camera> &camera,
+             const std::string &mode);
 void applyNoiseReduction(const std::shared_ptr<aditof::Camera> &camera,
                          int argc, char **argv);
-uint16_t *getNewFrame(const std::shared_ptr<aditof::Camera> &camera,
-                      aditof::Frame *frame);
+void getNewFrame(const std::shared_ptr<aditof::Camera> &camera,
+                 aditof::Frame *frame);
+uint16_t *getFrameData(aditof::Frame *frame, aditof::FrameDataType dataType);
 
 aditof::IntrinsicParameters
 getIntrinsics(const std::shared_ptr<aditof::Camera> &camera);

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/message_factory.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/message_factory.h
@@ -43,7 +43,8 @@ enum class MessageType {
 class MessageFactory {
   public:
     static AditofSensorMsg *
-    create(const std::shared_ptr<aditof::Camera> &camera, MessageType type);
+    create(const std::shared_ptr<aditof::Camera> &camera, aditof::Frame *frame,
+           MessageType type);
 };
 
 #endif // MESSAGE_FACTORY_H

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/pointcloud2_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/pointcloud2_msg.h
@@ -42,14 +42,19 @@
 
 class PointCloud2Msg : public AditofSensorMsg {
   public:
-    PointCloud2Msg();
-    PointCloud2Msg(const std::shared_ptr<aditof::Camera> &camera);
+    PointCloud2Msg(const std::shared_ptr<aditof::Camera> &camera,
+                   aditof::Frame *frame);
 
     /**
      * @brief Each message corresponds to one frame
      */
     sensor_msgs::PointCloud2 msg;
 
+    /**
+     * @brief Converts the frame data to a message
+     */
+    void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
+                        aditof::Frame *frame);
     /**
      * @brief Assigns values to the message fields concerning metadata
      */
@@ -59,16 +64,15 @@ class PointCloud2Msg : public AditofSensorMsg {
      * @brief Assigns values to the message fields concerning the point data
      */
     void setDataMembers(const std::shared_ptr<aditof::Camera> &camera,
-                        uint16_t *frameData);
-    /**
-     * @brief Converts the frame data to a message
-     */
-    void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera);
+                        aditof::Frame *frame);
 
     /**
      * @brief Publishes a message
      */
     void publishMsg(const ros::Publisher &pub);
+
+  private:
+    PointCloud2Msg();
 };
 
 #endif // POINTCLOUD2_MSG_H

--- a/bindings/ros/aditof_roscpp/src/message_factory.cpp
+++ b/bindings/ros/aditof_roscpp/src/message_factory.cpp
@@ -33,10 +33,10 @@
 
 AditofSensorMsg *
 MessageFactory::create(const std::shared_ptr<aditof::Camera> &camera,
-                       MessageType type) {
+                       aditof::Frame *frame, MessageType type) {
     switch (type) {
     case MessageType::sensor_msgs_PointCloud2:
-        return new PointCloud2Msg(camera);
+        return new PointCloud2Msg(camera, frame);
     }
     return nullptr;
 }


### PR DESCRIPTION
An AditofSensorMsg object is now created based on a Frame object.
In the previous version, creating a new message implied requesting
a new frame, which is incorrect.
This change is needed because the camera node will create different
types of messages based on the same frame.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>