### PR TITLE
bindings: ros: Use IR data to color point cloud

### DIFF
--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
@@ -49,5 +49,6 @@ aditof::IntrinsicParameters
 getIntrinsics(const std::shared_ptr<aditof::Camera> &camera);
 int getRangeMax(const std::shared_ptr<aditof::Camera> &camera);
 int getRangeMin(const std::shared_ptr<aditof::Camera> &camera);
+void irTo16bitGrayscale(uint16_t *frameData, int width, int height);
 
 #endif // ADITOF_UTILS_H

--- a/bindings/ros/aditof_roscpp/rviz/pointcloud.rviz
+++ b/bindings/ros/aditof_roscpp/rviz/pointcloud.rviz
@@ -42,7 +42,7 @@ Visualization Manager:
         Min Value: -10
         Value: true
       Axis: Z
-      Channel Name: rgb
+      Channel Name: intensity
       Class: rviz/PointCloud2
       Color: 255; 255; 255
       Color Transformer: Intensity
@@ -63,7 +63,7 @@ Visualization Manager:
       Topic: aditof_pcloud
       Unreliable: false
       Use Fixed Frame: true
-      Use rainbow: true
+      Use rainbow: false
       Value: true
   Enabled: true
   Global Options:

--- a/bindings/ros/aditof_roscpp/src/aditof_utils.cpp
+++ b/bindings/ros/aditof_roscpp/src/aditof_utils.cpp
@@ -188,3 +188,20 @@ int getRangeMin(const std::shared_ptr<Camera> &camera) {
     camera->getDetails(cameraDetails);
     return cameraDetails.minDepth;
 }
+
+void irTo16bitGrayscale(uint16_t *frameData, int width, int height) {
+    std::vector<uint16_t> data(frameData, frameData + width * height);
+
+    auto min_val = std::min_element(data.begin(), data.end());
+    auto max_val = std::max_element(data.begin(), data.end());
+    uint16_t delta = *max_val - *min_val;
+    int minColorValue = 0;
+
+    for (int i = 0; i < width * height; i++) {
+        float norm_val = static_cast<float>(data[i] - *min_val) / delta;
+        float grayscale_val =
+            norm_val * std::numeric_limits<unsigned short int>::max() +
+            (1.0f - norm_val) * minColorValue;
+        data[i] = static_cast<uint16_t>(grayscale_val);
+    }
+}


### PR DESCRIPTION
Use intensity channel instead of rgb channel and set
the values accordingly (IR data instead of depth data).

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>