### PR TITLE
bindings: ros: Add image and camera_info messages

### DIFF
--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/cameraInfo_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/cameraInfo_msg.h
@@ -29,24 +29,47 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MESSAGE_FACTORY_H
-#define MESSAGE_FACTORY_H
+#ifndef CAMERAINFO_MSG_H
+#define CAMERAINFO_MSG_H
 
-#include "depthImage_msg.h"
-#include "irImage_msg.h"
-#include "pointcloud2_msg.h"
+#include <boost/array.hpp>
+#include <string>
 
-enum class MessageType {
-    sensor_msgs_PointCloud2,
-    sensor_msgs_DepthImage,
-    sensor_msgs_IRImage
-};
+#include <aditof/frame.h>
+#include <glog/logging.h>
 
-class MessageFactory {
+#include "aditof_sensor_msg.h"
+#include "aditof_utils.h"
+
+#include <sensor_msgs/CameraInfo.h>
+
+class CameraInfoMsg : public AditofSensorMsg {
   public:
-    static AditofSensorMsg *
-    create(const std::shared_ptr<aditof::Camera> &camera, aditof::Frame *frame,
-           MessageType type);
+    CameraInfoMsg(const std::shared_ptr<aditof::Camera> &camera,
+                  aditof::Frame *frame);
+    /**
+     * @brief Each message corresponds to one frame
+     */
+    sensor_msgs::CameraInfo msg;
+
+    /**
+     * @brief Converts the frame data to a message
+     */
+    void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
+                        aditof::Frame *frame);
+    /**
+     * @brief Assigns values to the message fields
+     */
+    void setMembers(const std::shared_ptr<aditof::Camera> &camera, int width,
+                    int height);
+
+    /**
+     * @brief Publishes a message
+     */
+    void publishMsg(const ros::Publisher &pub);
+
+  private:
+    CameraInfoMsg();
 };
 
-#endif // MESSAGE_FACTORY_H
+#endif // CAMERAINFO_MSG_H

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/depthImage_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/depthImage_msg.h
@@ -1,0 +1,118 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2019, Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef DEPTHIMAGE_MSG_H
+#define DEPTHIMAGE_MSG_H
+
+#include <string>
+
+#include <aditof/camera.h>
+#include <aditof/frame.h>
+#include <glog/logging.h>
+
+#include "aditof_sensor_msg.h"
+#include "aditof_utils.h"
+
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
+
+//rainbow color map
+#define RED 0
+#define INDIGO 275
+
+//saturation and value, for hsv
+#define SAT 1.0
+#define VAL 1.0
+
+typedef struct Rgba8Color {
+    unsigned char r;
+    unsigned char g;
+    unsigned char b;
+    unsigned char a;
+} Rgba8Color;
+
+typedef struct Rgb32Color {
+    double r;
+    double g;
+    double b;
+} Rgb32Color;
+
+class DepthImageMsg : public AditofSensorMsg {
+  public:
+    DepthImageMsg(const std::shared_ptr<aditof::Camera> &camera,
+                  aditof::Frame *frame, std::string encoding);
+
+    /**
+     * @brief Each message corresponds to one frame
+     */
+    sensor_msgs::Image msg;
+
+    /**
+     * @brief Will be assigned a value from the list of strings in include/sensor_msgs/image_encodings.h
+     */
+    std::string imgEncoding;
+
+    /**
+     * @brief Converts the frame data to a message
+     */
+    void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
+                        aditof::Frame *frame);
+
+    /**
+     * @brief Assigns values to the message fields concerning metadata
+     */
+    void setMetadataMembers(int width, int height);
+
+    /**
+     * @brief Assigns values to the message fields concerning the point data
+     */
+    void setDataMembers(const std::shared_ptr<aditof::Camera> &camera,
+                        uint16_t *frameData);
+
+    /**
+     * @brief Converts depth data to RGBA8 color
+     */
+    void dataToRGBA8(uint16_t min_int, uint16_t max_int, uint16_t *data);
+
+    /**
+     * @brief Converts pixel value from HSV to RGBA
+     */
+    Rgba8Color HSVtoRGBA8(double hue, double sat, double val);
+    /**
+     * @brief Publishes a message
+     */
+    void publishMsg(const ros::Publisher &pub);
+
+  private:
+    DepthImageMsg();
+};
+
+#endif // DEPTHIMAGE_MSG_H

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/irImage_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/irImage_msg.h
@@ -29,24 +29,58 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef MESSAGE_FACTORY_H
-#define MESSAGE_FACTORY_H
+#ifndef IRIMAGE_MSG_H
+#define IRIMAGE_MSG_H
 
-#include "depthImage_msg.h"
-#include "irImage_msg.h"
-#include "pointcloud2_msg.h"
+#include <string>
 
-enum class MessageType {
-    sensor_msgs_PointCloud2,
-    sensor_msgs_DepthImage,
-    sensor_msgs_IRImage
-};
+#include <aditof/camera.h>
+#include <aditof/frame.h>
+#include <glog/logging.h>
 
-class MessageFactory {
+#include "aditof_sensor_msg.h"
+#include "aditof_utils.h"
+
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
+
+class IRImageMsg : public AditofSensorMsg {
   public:
-    static AditofSensorMsg *
-    create(const std::shared_ptr<aditof::Camera> &camera, aditof::Frame *frame,
-           MessageType type);
+    IRImageMsg(const std::shared_ptr<aditof::Camera> &camera,
+               aditof::Frame *frame, std::string encoding);
+    /**
+     * @brief Each message corresponds to one frame
+     */
+    sensor_msgs::Image msg;
+
+    /**
+     * @brief Will be assigned a value from the list of strings in include/sensor_msgs/image_encodings.h
+     */
+    std::string imgEncoding;
+
+    /**
+     * @brief Converts the frame data to a message
+     */
+    void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
+                        aditof::Frame *frame);
+    /**
+     * @brief Assigns values to the message fields concerning metadata
+     */
+    void setMetadataMembers(int width, int height);
+
+    /**
+     * @brief Assigns values to the message fields concerning the point data
+     */
+    void setDataMembers(const std::shared_ptr<aditof::Camera> &camera,
+                        uint16_t *frameData);
+
+    /**
+     * @brief Publishes a message
+     */
+    void publishMsg(const ros::Publisher &pub);
+
+  private:
+    IRImageMsg();
 };
 
-#endif // MESSAGE_FACTORY_H
+#endif // IRIMAGE_MSG_H

--- a/bindings/ros/aditof_roscpp/src/depthImage_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/depthImage_msg.cpp
@@ -1,0 +1,148 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2019, Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "depthImage_msg.h"
+using namespace aditof;
+
+DepthImageMsg::DepthImageMsg() {}
+
+DepthImageMsg::DepthImageMsg(const std::shared_ptr<aditof::Camera> &camera,
+                             aditof::Frame *frame, std::string encoding) {
+    imgEncoding = encoding;
+    FrameDataToMsg(camera, frame);
+}
+
+void DepthImageMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
+                                   aditof::Frame *frame) {
+    FrameDetails fDetails;
+    frame->getDetails(fDetails);
+
+    setMetadataMembers(fDetails.width, fDetails.height / 2);
+
+    uint16_t *frameData = getFrameData(frame, aditof::FrameDataType::DEPTH);
+    if (!frameData) {
+        LOG(ERROR) << "getFrameData call failed";
+        return;
+    }
+
+    setDataMembers(camera, frameData);
+}
+
+void DepthImageMsg::setMetadataMembers(int width, int height) {
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = "aditof_depth_img";
+
+    msg.width = width;
+    msg.height = height;
+    msg.encoding = imgEncoding;
+    msg.is_bigendian = false;
+
+    int pixelByteCnt = sensor_msgs::image_encodings::bitDepth(imgEncoding) / 8 *
+                       sensor_msgs::image_encodings::numChannels(imgEncoding);
+    msg.step = width * pixelByteCnt;
+
+    msg.data.resize(msg.step * height);
+}
+
+void DepthImageMsg::setDataMembers(const std::shared_ptr<Camera> &camera,
+                                   uint16_t *frameData) {
+    if (msg.encoding.compare(sensor_msgs::image_encodings::RGBA8) == 0) {
+        std::vector<uint16_t> depthData(frameData,
+                                        frameData + msg.width * msg.height);
+        auto min_range = std::min_element(depthData.begin(), depthData.end());
+
+        dataToRGBA8(*min_range, getRangeMax(camera), frameData);
+    } else
+        ROS_ERROR("Image encoding invalid or not available");
+}
+
+void DepthImageMsg::dataToRGBA8(uint16_t min_range, uint16_t max_range,
+                                uint16_t *data) {
+    uint8_t *msgDataPtr = msg.data.data();
+    int32_t delta = static_cast<uint32_t>(max_range - min_range);
+
+    for (unsigned int i = 0; i < msg.width * msg.height; i++) {
+        //normalized value
+        double norm_val = static_cast<double>(
+            static_cast<double>(data[i] - min_range) / delta);
+        double hue = norm_val * INDIGO + (1.0f - norm_val) * RED;
+
+        Rgba8Color color = HSVtoRGBA8(hue, SAT, VAL);
+        std::memcpy(msgDataPtr, &color, 4);
+        msgDataPtr += 4;
+    }
+}
+
+Rgba8Color DepthImageMsg::HSVtoRGBA8(double hue, double sat, double val) {
+    double c = 0.0, m = 0.0, x = 0.0;
+    double h = hue / 60.0;
+
+    c = sat * val;
+    x = c * (1.0 - std::abs(std::fmod(h, 2) - 1.0));
+    m = val - c;
+
+    Rgb32Color rgb32;
+
+    rgb32.r = m;
+    rgb32.g = m;
+    rgb32.b = m;
+
+    if (h <= 1.0) {
+        rgb32.r += c;
+        rgb32.g += x;
+    } else if (h <= 2.0) {
+        rgb32.r += x;
+        rgb32.g += c;
+    } else if (h <= 3.0) {
+        rgb32.g += c;
+        rgb32.b += x;
+    } else if (h <= 4.0) {
+        rgb32.g += x;
+        rgb32.b += c;
+    } else if (h <= 5.0) {
+        rgb32.r += x;
+        rgb32.b += c;
+    } else if (h <= 6.0) {
+        rgb32.r += c;
+        rgb32.b += x;
+    }
+
+    Rgba8Color rgba8;
+
+    rgba8.r = floor(rgb32.r >= 1.0 ? 255 : rgb32.r * 256.0);
+    rgba8.g = floor(rgb32.g >= 1.0 ? 255 : rgb32.g * 256.0);
+    rgba8.b = floor(rgb32.b >= 1.0 ? 255 : rgb32.b * 256.0);
+    rgba8.a = 0XFF;
+
+    return rgba8;
+}
+
+void DepthImageMsg::publishMsg(const ros::Publisher &pub) { pub.publish(msg); }

--- a/bindings/ros/aditof_roscpp/src/irImage_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/irImage_msg.cpp
@@ -1,0 +1,85 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2019, Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "irImage_msg.h"
+using namespace aditof;
+
+IRImageMsg::IRImageMsg() {}
+
+IRImageMsg::IRImageMsg(const std::shared_ptr<aditof::Camera> &camera,
+                       aditof::Frame *frame, std::string encoding) {
+    imgEncoding = encoding;
+    FrameDataToMsg(camera, frame);
+}
+
+void IRImageMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
+                                aditof::Frame *frame) {
+    FrameDetails fDetails;
+    frame->getDetails(fDetails);
+
+    setMetadataMembers(fDetails.width, fDetails.height / 2);
+
+    uint16_t *frameData = getFrameData(frame, aditof::FrameDataType::IR);
+    if (!frameData) {
+        LOG(ERROR) << "getFrameData call failed";
+        return;
+    }
+
+    setDataMembers(camera, frameData);
+}
+
+void IRImageMsg::setMetadataMembers(int width, int height) {
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = "aditof_ir_img";
+
+    msg.width = width;
+    msg.height = height;
+    msg.encoding = imgEncoding;
+    msg.is_bigendian = false;
+
+    int pixelByteCnt = sensor_msgs::image_encodings::bitDepth(imgEncoding) / 8 *
+                       sensor_msgs::image_encodings::numChannels(imgEncoding);
+    msg.step = width * pixelByteCnt;
+
+    msg.data.resize(msg.step * height);
+}
+
+void IRImageMsg::setDataMembers(const std::shared_ptr<Camera> &camera,
+                                uint16_t *frameData) {
+    if (msg.encoding.compare(sensor_msgs::image_encodings::MONO16) == 0) {
+        irTo16bitGrayscale(frameData, msg.width, msg.height);
+        uint8_t *msgDataPtr = msg.data.data();
+        std::memcpy(msgDataPtr, frameData, msg.step * msg.height);
+    } else
+        ROS_ERROR("Image encoding invalid or not available");
+}
+
+void IRImageMsg::publishMsg(const ros::Publisher &pub) { pub.publish(msg); }

--- a/bindings/ros/aditof_roscpp/src/message_factory.cpp
+++ b/bindings/ros/aditof_roscpp/src/message_factory.cpp
@@ -37,6 +37,12 @@ MessageFactory::create(const std::shared_ptr<aditof::Camera> &camera,
     switch (type) {
     case MessageType::sensor_msgs_PointCloud2:
         return new PointCloud2Msg(camera, frame);
+    case MessageType::sensor_msgs_DepthImage:
+        return new DepthImageMsg(camera, frame,
+                                 sensor_msgs::image_encodings::RGBA8);
+    case MessageType::sensor_msgs_IRImage:
+        return new IRImageMsg(camera, frame,
+                              sensor_msgs::image_encodings::MONO16);
     }
     return nullptr;
 }


### PR DESCRIPTION
Added  new classes that encapsulate the CameraInfo and
Image messages defined in the ros package sensor_msgs.
There are two types for the Image message, an 8-bit
RGB depth image and a 16-bit grayscale IR one.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>