### PR TITLE
utils: dragonboard: restart config pipe service if it fails

### DIFF
--- a/utils/dragonboard/config_pipe.service
+++ b/utils/dragonboard/config_pipe.service
@@ -4,6 +4,8 @@ StartLimitIntervalSec=10
 [Service]
 User=root
 ExecStart=/home/linaro/workspace/github/aditof_sdk/utils/dragonboard/config_pipe.sh
+Restart=on-failure
+RestartSec=3s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a trivial service that needs to start successfully in order to have
the aditof-demo running, otherwise a manual run of the config-pipe.sh
script is needed. On some "boots" this service fails to start due to being
unable to open "/dev/media1". In this case the service could try to restart
after a while, and keep restarting until it is successful


