### PR TITLE
bindings: ros: Ros camera_node

### DIFF
--- a/bindings/ros/aditof_roscpp/CMakeLists.txt
+++ b/bindings/ros/aditof_roscpp/CMakeLists.txt
@@ -3,21 +3,33 @@ project(aditof_roscpp)
 
 option(WITH_ROS_EXAMPLES "Build ROS examples" ON)
 
-list(APPEND CMAKE_PREFIX_PATH ${ADITOF_CMAKE_INSTALL_PREFIX} ${ADITOF_CMAKE_PREFIX_PATH})
+list(APPEND CMAKE_PREFIX_PATH ${ADITOF_CMAKE_INSTALL_PREFIX}
+     ${ADITOF_CMAKE_PREFIX_PATH})
 
 # Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs)
 find_package(aditof ${VERSION} REQUIRED)
 
-include_directories(include/${PROJECT_NAME} ${catkin_INCLUDE_DIRS} ${aditof_INCLUDE_DIRS})
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp sensor_msgs
+  DEPENDS aditof)
 
-catkin_package(INCLUDE_DIRS include CATKIN_DEPENDS roscpp sensor_msgs DEPENDS aditof )
+include_directories(include/${PROJECT_NAME} ${catkin_INCLUDE_DIRS}
+                    ${aditof_INCLUDE_DIRS})
 
+file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
+list(REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/camera_node.cpp)
+
+add_executable(aditof_camera_node
+               ${CMAKE_CURRENT_SOURCE_DIR}/src/camera_node.cpp ${SOURCES})
+target_sources(aditof_camera_node
+               INTERFACE ${CMAKE_SOURCE_DIR}/include/${PROJECT_NAME})
+target_link_libraries(aditof_camera_node aditof::aditof)
+target_link_libraries(aditof_camera_node ${catkin_LIBRARIES})
 
 if(WITH_ROS_EXAMPLES)
   find_package(catkin REQUIRED COMPONENTS rviz)
-
-  file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
   add_executable(
     aditof_rviz_pcl ${CMAKE_CURRENT_SOURCE_DIR}/src/examples/rviz_pointcloud.cpp

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/message_factory.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/message_factory.h
@@ -32,6 +32,7 @@
 #ifndef MESSAGE_FACTORY_H
 #define MESSAGE_FACTORY_H
 
+#include "cameraInfo_msg.h"
 #include "depthImage_msg.h"
 #include "irImage_msg.h"
 #include "pointcloud2_msg.h"
@@ -39,7 +40,8 @@
 enum class MessageType {
     sensor_msgs_PointCloud2,
     sensor_msgs_DepthImage,
-    sensor_msgs_IRImage
+    sensor_msgs_IRImage,
+    sensor_msgs_CameraInfo
 };
 
 class MessageFactory {

--- a/bindings/ros/aditof_roscpp/src/camera_node.cpp
+++ b/bindings/ros/aditof_roscpp/src/camera_node.cpp
@@ -1,0 +1,123 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2019, Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "message_factory.h"
+#include <aditof_utils.h>
+#include <ros/ros.h>
+
+using namespace aditof;
+
+int main(int argc, char **argv) {
+
+    std::shared_ptr<Camera> camera = initCamera(argc, argv);
+    ROS_ASSERT_MSG(camera, "initCamera call failed");
+
+    setFrameType(camera, "depth_ir");
+    setMode(camera, "medium");
+
+    ros::init(argc, argv, "aditof_camera_node");
+
+    //create publishers
+    ros::NodeHandle nHandle;
+    ros::Publisher pcl_pubisher =
+        nHandle.advertise<sensor_msgs::PointCloud2>("aditof_pcloud", 5);
+    ROS_ASSERT_MSG(pcl_pubisher, "creating pcl_pubisher failed");
+
+    ros::Publisher depth_img_pubisher =
+        nHandle.advertise<sensor_msgs::Image>("aditof_depth", 5);
+    ROS_ASSERT_MSG(depth_img_pubisher, "creating depth_img_pubisher failed");
+
+    ros::Publisher ir_img_pubisher =
+        nHandle.advertise<sensor_msgs::Image>("aditof_ir", 5);
+    ROS_ASSERT_MSG(ir_img_pubisher, "creating ir_img_pubisher failed");
+
+    ros::Publisher camera_info_pubisher =
+        nHandle.advertise<sensor_msgs::CameraInfo>("aditof_camera_info", 5);
+    ROS_ASSERT_MSG(camera_info_pubisher,
+                   "creating camera_info_pubisher failed");
+
+    applyNoiseReduction(camera, argc, argv);
+
+    Frame frame;
+    getNewFrame(camera, &frame);
+
+    //create messages
+    AditofSensorMsg *pcl_msg = MessageFactory::create(
+        camera, &frame, MessageType::sensor_msgs_PointCloud2);
+    ROS_ASSERT_MSG(pcl_msg, "pointcloud message creation failed");
+    PointCloud2Msg *pclMsg = dynamic_cast<PointCloud2Msg *>(pcl_msg);
+    ROS_ASSERT_MSG(pclMsg,
+                   "downcast from AditofSensorMsg to PointCloud2Msg failed");
+
+    AditofSensorMsg *depth_img_msg = MessageFactory::create(
+        camera, &frame, MessageType::sensor_msgs_DepthImage);
+    ROS_ASSERT_MSG(depth_img_msg, "depth_image message creation failed");
+    DepthImageMsg *depthImgMsg = dynamic_cast<DepthImageMsg *>(depth_img_msg);
+    ROS_ASSERT_MSG(depthImgMsg,
+                   "downcast from AditofSensorMsg to DepthImageMsg failed");
+
+    AditofSensorMsg *ir_img_msg = MessageFactory::create(
+        camera, &frame, MessageType::sensor_msgs_IRImage);
+    ROS_ASSERT_MSG(ir_img_msg, "ir_image message creation failed");
+    IRImageMsg *irImgMsg = dynamic_cast<IRImageMsg *>(ir_img_msg);
+    ROS_ASSERT_MSG(irImgMsg,
+                   "downcast from AditofSensorMsg to IRImageMsg failed");
+
+    AditofSensorMsg *camera_info_msg = MessageFactory::create(
+        camera, &frame, MessageType::sensor_msgs_CameraInfo);
+    ROS_ASSERT_MSG(camera_info_msg, "camera_info_msg message creation failed");
+    CameraInfoMsg *cameraInfoMsg =
+        dynamic_cast<CameraInfoMsg *>(camera_info_msg);
+    ROS_ASSERT_MSG(cameraInfoMsg,
+                   "downcast from AditofSensorMsg to CameraInfoMsg failed");
+
+    while (ros::ok()) {
+        getNewFrame(camera, &frame);
+
+        pclMsg->FrameDataToMsg(camera, &frame);
+        pclMsg->publishMsg(pcl_pubisher);
+
+        depthImgMsg->FrameDataToMsg(camera, &frame);
+        depthImgMsg->publishMsg(depth_img_pubisher);
+
+        irImgMsg->FrameDataToMsg(camera, &frame);
+        irImgMsg->publishMsg(ir_img_pubisher);
+
+        cameraInfoMsg->FrameDataToMsg(camera, &frame);
+        cameraInfoMsg->publishMsg(camera_info_pubisher);
+    }
+
+    delete pcl_msg;
+    delete depth_img_msg;
+    delete ir_img_msg;
+    delete camera_info_msg;
+    return 0;
+}

--- a/bindings/ros/aditof_roscpp/src/message_factory.cpp
+++ b/bindings/ros/aditof_roscpp/src/message_factory.cpp
@@ -43,6 +43,8 @@ MessageFactory::create(const std::shared_ptr<aditof::Camera> &camera,
     case MessageType::sensor_msgs_IRImage:
         return new IRImageMsg(camera, frame,
                               sensor_msgs::image_encodings::MONO16);
+    case MessageType::sensor_msgs_CameraInfo:
+        return new CameraInfoMsg(camera, frame);
     }
     return nullptr;
 }


### PR DESCRIPTION
bindings: ros: message factory missing type - Add missing message type needed by the camera node
bindings: ros: Add camera node - The camera node is used to publish all message types supported     by the aditof_roscpp package.