### PR TITLE
bindings: ros: Fix connection type bug

### DIFF
--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
@@ -37,6 +37,7 @@
 #include <aditof/camera_chicony_specifics.h>
 #include <glog/logging.h>
 
+std::string parseArgs(int argc, char **argv);
 std::shared_ptr<aditof::Camera> initCamera(int argc, char **argv);
 void setFrameType(const std::shared_ptr<aditof::Camera> &camera,
                   const std::string &type);

--- a/bindings/ros/aditof_roscpp/launch/camera_node.launch
+++ b/bindings/ros/aditof_roscpp/launch/camera_node.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="ip"/>
+  <arg name="ip" default='""'/>
   <node pkg="aditof_roscpp" type="aditof_camera_node" name="aditof_camera_node" args="$(arg ip)" output="screen"/>
   <node pkg="rqt_reconfigure" type="rqt_reconfigure" name="reconfigParams"/>
 </launch>

--- a/bindings/ros/aditof_roscpp/launch/rviz_publisher.launch
+++ b/bindings/ros/aditof_roscpp/launch/rviz_publisher.launch
@@ -1,7 +1,6 @@
 <launch>
-  <arg name="ip"/>
-  <arg name="threshold" default="70"/>
-  <node pkg="aditof_roscpp" type="aditof_rviz_pcl" name="pclRviz" args="$(arg ip) $(arg threshold)" output="screen"/>
+  <arg name="ip" default='""'/>
+  <node pkg="aditof_roscpp" type="aditof_rviz_pcl" name="pclRviz" args="$(arg ip)" output="screen"/>
   <node pkg="tf" type="static_transform_publisher" name="transform" args="0 0 0 0 1.57 1.57 base_link pointcloud 20"/>
   <node type="rviz" name="rviz" pkg="rviz" args="-d $(find aditof_roscpp)/rviz/pointcloud.rviz"/>
 </launch>

--- a/bindings/ros/aditof_roscpp/src/aditof_utils.cpp
+++ b/bindings/ros/aditof_roscpp/src/aditof_utils.cpp
@@ -37,18 +37,26 @@
 #include <ros/ros.h>
 
 using namespace aditof;
-std::shared_ptr<Camera> initCamera(int argc, char **argv) {
+
+std::string parseArgs(int argc, char **argv) {
     google::InitGoogleLogging(argv[0]);
     FLAGS_alsologtostderr = 1;
-    Status status = Status::OK;
-    std::string ip;
 
-    if (argc < 2) {
-        LOG(INFO) << "No ip provided, attempting to connect to the camera "
-                     "through USB";
-    } else {
-        ip = argv[1];
+    if (argc > 1) {
+        std::string ip = argv[1];
+        if (!ip.empty()) {
+            return ip;
+        }
     }
+    LOG(INFO)
+        << "No ip provided, attempting to connect to the camera through USB";
+    return std::string();
+}
+
+std::shared_ptr<Camera> initCamera(int argc, char **argv) {
+
+    Status status = Status::OK;
+    std::string ip = parseArgs(argc, argv);
 
     System system;
     status = system.initialize();


### PR DESCRIPTION
This commit adds the parseArgs function, used to obtain the IP
parameter, if it exists. Otherwise, the USB connection type is employed.
Also changed both launch files in order to set a default value for the IP
param and removed threshold as command line argument from launch file.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>