### PR TITLE
bindings: ros: Fix ir image message

### DIFF
--- a/bindings/ros/aditof_roscpp/src/aditof_utils.cpp
+++ b/bindings/ros/aditof_roscpp/src/aditof_utils.cpp
@@ -224,6 +224,6 @@ void irTo16bitGrayscale(uint16_t *frameData, int width, int height) {
         float grayscale_val =
             norm_val * std::numeric_limits<unsigned short int>::max() +
             (1.0f - norm_val) * minColorValue;
-        data[i] = static_cast<uint16_t>(grayscale_val);
+        frameData[i] = static_cast<uint16_t>(grayscale_val);
     }
 }


### PR DESCRIPTION
Before this commit, the data array given as parameter to
the irTo16bitGrayscale function was not updated with
the values resulted after processing.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>