### PR TITLE
bindings: ros: add IR gamma correction parameter

### DIFF
--- a/bindings/ros/aditof_roscpp/cfg/Aditof_roscpp.cfg
+++ b/bindings/ros/aditof_roscpp/cfg/Aditof_roscpp.cfg
@@ -19,13 +19,15 @@ rev_enum = gen.enum([revb_var, revc_var], "Camera revision options")
 group_96tof = gen.add_group("Camera 96Tof1", type="hide", state=True)
 group_chichony = gen.add_group("Camera Chicony", type="hide", state=True)
 
+group_96tof.add("ir_gamma", double_t, 0, "IR gamma correction", 1, 0, 1)
 group_96tof.add("mode", int_t, 0, "Camera mode", 1, 0, 2,
                 edit_method=mode_enum_96)
 group1a = group_96tof.add_group("Noise reduction", type="hide", state = True)
 group1a.add("threshold", int_t, 0, "Noise reduction threshold", 0, 0, 16383)
-group_96tof.add("revision", int_t, 0, "Camera revision", 0, 0, 1,
+group_96tof.add("revision", int_t, 0, "Camera revision", 1, 0, 1,
                edit_method=rev_enum)
 
+group_chichony.add("ir_gamma_chicony", double_t, 0, "IR gamma correction", 1, 0, 1)
 group_chichony.add("mode_chicony", int_t, 0, "Camera mode parameter ", 0, 0, 0,
                  edit_method=mode_enum_chicony)
 group1b = group_chichony.add_group("Noise reduction_chicony", type="hide",

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_utils.h
@@ -45,6 +45,8 @@ void setMode(const std::shared_ptr<aditof::Camera> &camera,
              const std::string &mode);
 void setCameraRevision(const std::shared_ptr<aditof::Camera> &camera,
                        aditof::Revision rev);
+void setIrGammaCorrection(const std::shared_ptr<aditof::Camera> &camera,
+                          float gamma);
 void applyNoiseReduction(const std::shared_ptr<aditof::Camera> &camera,
                          int threshold);
 void disableNoiseReduction(const std::shared_ptr<aditof::Camera> &camera);

--- a/bindings/ros/aditof_roscpp/src/camera_node.cpp
+++ b/bindings/ros/aditof_roscpp/src/camera_node.cpp
@@ -77,26 +77,23 @@ void callback(aditof_roscpp::Aditof_roscppConfig &config, uint32_t level,
             setCameraRevision(camera, Revision::RevC);
             break;
         }
+        setIrGammaCorrection(camera, config.ir_gamma);
+
     } else {
         CameraChicony *camChicony = dynamic_cast<CameraChicony *>(camera.get());
         if (camChicony) {
             config.groups.camera_96tof1.state = false;
             config.groups.camera_chicony.state = true;
+
             switch (config.mode_chicony) {
             case 0:
                 setMode(camera, "near");
                 applyNoiseReduction(camera, config.threshold);
                 break;
             }
+            setIrGammaCorrection(camera, config.ir_gamma_chicony);
         }
     }
-
-    /*
-  ROS_INFO("Reconfigure Request: %d %f %s %d",
-            config.threshold, config.double_param,
-            config.bool_param?"True":"False",
-            config.camera_mode);
-            */
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This commit adds the option to change the ir gamma correction
parameter's value from the rqt_reconfigure interface.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>