### PR TITLE
Demo: Ui fixes - gamma correction

### DIFF
--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -844,8 +844,15 @@ void AdiTofDemoView::render() {
 
         if (valueFieldSelectedG) {
             if ((key >= 48 && key <= 57) || (key == 46)) {
-                valueG += pressedValidKey;
-                IRGamma = stof(valueG);
+                if ((valueG.size() < 11)) {
+                    try {
+                        valueG += pressedValidKey;
+                        IRGamma = stof(valueG);
+                    } catch (const std::invalid_argument &ia) {
+                        status = "Input for IRGamma must be float!";
+                        valueG = valueG.substr(0, valueG.size() - 1);
+                    }
+                }
             } else if (backspace) {
                 valueG = valueG.substr(0, valueG.size() - 1);
                 if (valueG.compare("") != 0) {


### PR DESCRIPTION
Added length limit for gamma correction value input.
Made sure the user cannot input for gamma correction ".", as a start value, as this generates a fatal error.
Made sure only one "." can be inputed for the gamma correction value.

Signed-off-by: Andreea Grigorovici <andreea.grigorovici@analog.com>