### PR TITLE
bindings: ros: Fix messages timestamp

### DIFF
--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_sensor_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/aditof_sensor_msg.h
@@ -34,12 +34,13 @@
 
 #include <aditof/camera.h>
 #include <ros/publisher.h>
+#include <ros/time.h>
 
 class AditofSensorMsg {
   public:
     virtual ~AditofSensorMsg() = default;
     virtual void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
-                                aditof::Frame *frame) = 0;
+                                aditof::Frame *frame, ros::Time tStamp) = 0;
     virtual void publishMsg(const ros::Publisher &pub) = 0;
 };
 

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/cameraInfo_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/cameraInfo_msg.h
@@ -46,7 +46,7 @@
 class CameraInfoMsg : public AditofSensorMsg {
   public:
     CameraInfoMsg(const std::shared_ptr<aditof::Camera> &camera,
-                  aditof::Frame *frame);
+                  aditof::Frame *frame, ros::Time tStamp);
     /**
      * @brief Each message corresponds to one frame
      */
@@ -56,12 +56,12 @@ class CameraInfoMsg : public AditofSensorMsg {
      * @brief Converts the frame data to a message
      */
     void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
-                        aditof::Frame *frame);
+                        aditof::Frame *frame, ros::Time tStamp);
     /**
      * @brief Assigns values to the message fields
      */
     void setMembers(const std::shared_ptr<aditof::Camera> &camera, int width,
-                    int height);
+                    int height, ros::Time tStamp);
 
     /**
      * @brief Publishes a message

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/depthImage_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/depthImage_msg.h
@@ -64,7 +64,7 @@ typedef struct Rgb32Color {
 class DepthImageMsg : public AditofSensorMsg {
   public:
     DepthImageMsg(const std::shared_ptr<aditof::Camera> &camera,
-                  aditof::Frame *frame, std::string encoding);
+                  aditof::Frame *frame, std::string encoding, ros::Time tStamp);
 
     /**
      * @brief Each message corresponds to one frame
@@ -80,12 +80,12 @@ class DepthImageMsg : public AditofSensorMsg {
      * @brief Converts the frame data to a message
      */
     void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
-                        aditof::Frame *frame);
+                        aditof::Frame *frame, ros::Time tStamp);
 
     /**
      * @brief Assigns values to the message fields concerning metadata
      */
-    void setMetadataMembers(int width, int height);
+    void setMetadataMembers(int width, int height, ros::Time tStamp);
 
     /**
      * @brief Assigns values to the message fields concerning the point data

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/irImage_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/irImage_msg.h
@@ -43,7 +43,7 @@
 class IRImageMsg : public AditofSensorMsg {
   public:
     IRImageMsg(const std::shared_ptr<aditof::Camera> &camera,
-               aditof::Frame *frame, std::string encoding);
+               aditof::Frame *frame, std::string encoding, ros::Time tStamp);
     /**
      * @brief Each message corresponds to one frame
      */
@@ -58,11 +58,11 @@ class IRImageMsg : public AditofSensorMsg {
      * @brief Converts the frame data to a message
      */
     void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
-                        aditof::Frame *frame);
+                        aditof::Frame *frame, ros::Time tStamp);
     /**
      * @brief Assigns values to the message fields concerning metadata
      */
-    void setMetadataMembers(int width, int height);
+    void setMetadataMembers(int width, int height, ros::Time tStamp);
 
     /**
      * @brief Assigns values to the message fields concerning the point data

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/message_factory.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/message_factory.h
@@ -48,7 +48,7 @@ class MessageFactory {
   public:
     static AditofSensorMsg *
     create(const std::shared_ptr<aditof::Camera> &camera, aditof::Frame *frame,
-           MessageType type);
+           MessageType type, ros::Time tStamp);
 };
 
 #endif // MESSAGE_FACTORY_H

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/pointcloud2_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/pointcloud2_msg.h
@@ -41,7 +41,7 @@
 class PointCloud2Msg : public AditofSensorMsg {
   public:
     PointCloud2Msg(const std::shared_ptr<aditof::Camera> &camera,
-                   aditof::Frame *frame);
+                   aditof::Frame *frame, ros::Time tStamp);
 
     /**
      * @brief Each message corresponds to one frame
@@ -52,11 +52,11 @@ class PointCloud2Msg : public AditofSensorMsg {
      * @brief Converts the frame data to a message
      */
     void FrameDataToMsg(const std::shared_ptr<aditof::Camera> &camera,
-                        aditof::Frame *frame);
+                        aditof::Frame *frame, ros::Time tStamp);
     /**
      * @brief Assigns values to the message fields concerning metadata
      */
-    void setMetadataMembers(int width, int height);
+    void setMetadataMembers(int width, int height, ros::Time tStamp);
 
     /**
      * @brief Assigns values to the message fields concerning the point data

--- a/bindings/ros/aditof_roscpp/src/cameraInfo_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/cameraInfo_msg.cpp
@@ -36,21 +36,21 @@ using namespace aditof;
 CameraInfoMsg::CameraInfoMsg() {}
 
 CameraInfoMsg::CameraInfoMsg(const std::shared_ptr<aditof::Camera> &camera,
-                             aditof::Frame *frame) {
-    FrameDataToMsg(camera, frame);
+                             aditof::Frame *frame, ros::Time tStamp) {
+    FrameDataToMsg(camera, frame, tStamp);
 }
 
 void CameraInfoMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
-                                   aditof::Frame *frame) {
+                                   aditof::Frame *frame, ros::Time tStamp) {
     FrameDetails fDetails;
     frame->getDetails(fDetails);
 
-    setMembers(camera, fDetails.width, fDetails.height / 2);
+    setMembers(camera, fDetails.width, fDetails.height / 2, tStamp);
 }
 
 void CameraInfoMsg::setMembers(const std::shared_ptr<Camera> &camera, int width,
-                               int height) {
-    msg.header.stamp = ros::Time::now();
+                               int height, ros::Time tStamp) {
+    msg.header.stamp = tStamp;
     msg.header.frame_id = "aditof_camera_info";
 
     msg.width = width;

--- a/bindings/ros/aditof_roscpp/src/camera_node.cpp
+++ b/bindings/ros/aditof_roscpp/src/camera_node.cpp
@@ -135,29 +135,30 @@ int main(int argc, char **argv) {
     getNewFrame(camera, &frame);
 
     //create messages
+    ros::Time timeStamp = ros::Time::now();
     AditofSensorMsg *pcl_msg = MessageFactory::create(
-        camera, &frame, MessageType::sensor_msgs_PointCloud2);
+        camera, &frame, MessageType::sensor_msgs_PointCloud2, timeStamp);
     ROS_ASSERT_MSG(pcl_msg, "pointcloud message creation failed");
     PointCloud2Msg *pclMsg = dynamic_cast<PointCloud2Msg *>(pcl_msg);
     ROS_ASSERT_MSG(pclMsg,
                    "downcast from AditofSensorMsg to PointCloud2Msg failed");
 
     AditofSensorMsg *depth_img_msg = MessageFactory::create(
-        camera, &frame, MessageType::sensor_msgs_DepthImage);
+        camera, &frame, MessageType::sensor_msgs_DepthImage, timeStamp);
     ROS_ASSERT_MSG(depth_img_msg, "depth_image message creation failed");
     DepthImageMsg *depthImgMsg = dynamic_cast<DepthImageMsg *>(depth_img_msg);
     ROS_ASSERT_MSG(depthImgMsg,
                    "downcast from AditofSensorMsg to DepthImageMsg failed");
 
     AditofSensorMsg *ir_img_msg = MessageFactory::create(
-        camera, &frame, MessageType::sensor_msgs_IRImage);
+        camera, &frame, MessageType::sensor_msgs_IRImage, timeStamp);
     ROS_ASSERT_MSG(ir_img_msg, "ir_image message creation failed");
     IRImageMsg *irImgMsg = dynamic_cast<IRImageMsg *>(ir_img_msg);
     ROS_ASSERT_MSG(irImgMsg,
                    "downcast from AditofSensorMsg to IRImageMsg failed");
 
     AditofSensorMsg *camera_info_msg = MessageFactory::create(
-        camera, &frame, MessageType::sensor_msgs_CameraInfo);
+        camera, &frame, MessageType::sensor_msgs_CameraInfo, timeStamp);
     ROS_ASSERT_MSG(camera_info_msg, "camera_info_msg message creation failed");
     CameraInfoMsg *cameraInfoMsg =
         dynamic_cast<CameraInfoMsg *>(camera_info_msg);
@@ -165,18 +166,19 @@ int main(int argc, char **argv) {
                    "downcast from AditofSensorMsg to CameraInfoMsg failed");
 
     while (ros::ok()) {
+        ros::Time tStamp = ros::Time::now();
         getNewFrame(camera, &frame);
 
-        pclMsg->FrameDataToMsg(camera, &frame);
+        pclMsg->FrameDataToMsg(camera, &frame, tStamp);
         pclMsg->publishMsg(pcl_pubisher);
 
-        depthImgMsg->FrameDataToMsg(camera, &frame);
+        depthImgMsg->FrameDataToMsg(camera, &frame, tStamp);
         depthImgMsg->publishMsg(depth_img_pubisher);
 
-        irImgMsg->FrameDataToMsg(camera, &frame);
+        irImgMsg->FrameDataToMsg(camera, &frame, tStamp);
         irImgMsg->publishMsg(ir_img_pubisher);
 
-        cameraInfoMsg->FrameDataToMsg(camera, &frame);
+        cameraInfoMsg->FrameDataToMsg(camera, &frame, tStamp);
         cameraInfoMsg->publishMsg(camera_info_pubisher);
 
         ros::spinOnce();

--- a/bindings/ros/aditof_roscpp/src/depthImage_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/depthImage_msg.cpp
@@ -35,17 +35,18 @@ using namespace aditof;
 DepthImageMsg::DepthImageMsg() {}
 
 DepthImageMsg::DepthImageMsg(const std::shared_ptr<aditof::Camera> &camera,
-                             aditof::Frame *frame, std::string encoding) {
+                             aditof::Frame *frame, std::string encoding,
+                             ros::Time tStamp) {
     imgEncoding = encoding;
-    FrameDataToMsg(camera, frame);
+    FrameDataToMsg(camera, frame, tStamp);
 }
 
 void DepthImageMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
-                                   aditof::Frame *frame) {
+                                   aditof::Frame *frame, ros::Time tStamp) {
     FrameDetails fDetails;
     frame->getDetails(fDetails);
 
-    setMetadataMembers(fDetails.width, fDetails.height / 2);
+    setMetadataMembers(fDetails.width, fDetails.height / 2, tStamp);
 
     uint16_t *frameData = getFrameData(frame, aditof::FrameDataType::DEPTH);
     if (!frameData) {
@@ -56,8 +57,9 @@ void DepthImageMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
     setDataMembers(camera, frameData);
 }
 
-void DepthImageMsg::setMetadataMembers(int width, int height) {
-    msg.header.stamp = ros::Time::now();
+void DepthImageMsg::setMetadataMembers(int width, int height,
+                                       ros::Time tStamp) {
+    msg.header.stamp = tStamp;
     msg.header.frame_id = "aditof_depth_img";
 
     msg.width = width;

--- a/bindings/ros/aditof_roscpp/src/examples/rviz_pointcloud.cpp
+++ b/bindings/ros/aditof_roscpp/src/examples/rviz_pointcloud.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     getNewFrame(camera, &frame);
 
     AditofSensorMsg *msg = MessageFactory::create(
-        camera, &frame, MessageType::sensor_msgs_PointCloud2);
+        camera, &frame, MessageType::sensor_msgs_PointCloud2, ros::Time::now());
 
     if (!msg) {
         ROS_ERROR("pointcloud message creation failed");
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
             ROS_ERROR("downcast from AditofSensorMsg to PointCloud2Msg failed");
             return -1;
         }
-        pclMsg->FrameDataToMsg(camera, &frame);
+        pclMsg->FrameDataToMsg(camera, &frame, ros::Time::now());
         pclMsg->publishMsg(frame_pubisher);
     }
 

--- a/bindings/ros/aditof_roscpp/src/irImage_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/irImage_msg.cpp
@@ -35,17 +35,18 @@ using namespace aditof;
 IRImageMsg::IRImageMsg() {}
 
 IRImageMsg::IRImageMsg(const std::shared_ptr<aditof::Camera> &camera,
-                       aditof::Frame *frame, std::string encoding) {
+                       aditof::Frame *frame, std::string encoding,
+                       ros::Time tStamp) {
     imgEncoding = encoding;
-    FrameDataToMsg(camera, frame);
+    FrameDataToMsg(camera, frame, tStamp);
 }
 
 void IRImageMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
-                                aditof::Frame *frame) {
+                                aditof::Frame *frame, ros::Time tStamp) {
     FrameDetails fDetails;
     frame->getDetails(fDetails);
 
-    setMetadataMembers(fDetails.width, fDetails.height / 2);
+    setMetadataMembers(fDetails.width, fDetails.height / 2, tStamp);
 
     uint16_t *frameData = getFrameData(frame, aditof::FrameDataType::IR);
     if (!frameData) {
@@ -56,8 +57,8 @@ void IRImageMsg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
     setDataMembers(camera, frameData);
 }
 
-void IRImageMsg::setMetadataMembers(int width, int height) {
-    msg.header.stamp = ros::Time::now();
+void IRImageMsg::setMetadataMembers(int width, int height, ros::Time tStamp) {
+    msg.header.stamp = tStamp;
     msg.header.frame_id = "aditof_ir_img";
 
     msg.width = width;

--- a/bindings/ros/aditof_roscpp/src/message_factory.cpp
+++ b/bindings/ros/aditof_roscpp/src/message_factory.cpp
@@ -33,18 +33,19 @@
 
 AditofSensorMsg *
 MessageFactory::create(const std::shared_ptr<aditof::Camera> &camera,
-                       aditof::Frame *frame, MessageType type) {
+                       aditof::Frame *frame, MessageType type,
+                       ros::Time tStamp) {
     switch (type) {
     case MessageType::sensor_msgs_PointCloud2:
-        return new PointCloud2Msg(camera, frame);
+        return new PointCloud2Msg(camera, frame, tStamp);
     case MessageType::sensor_msgs_DepthImage:
         return new DepthImageMsg(camera, frame,
-                                 sensor_msgs::image_encodings::RGBA8);
+                                 sensor_msgs::image_encodings::RGBA8, tStamp);
     case MessageType::sensor_msgs_IRImage:
         return new IRImageMsg(camera, frame,
-                              sensor_msgs::image_encodings::MONO16);
+                              sensor_msgs::image_encodings::MONO16, tStamp);
     case MessageType::sensor_msgs_CameraInfo:
-        return new CameraInfoMsg(camera, frame);
+        return new CameraInfoMsg(camera, frame, tStamp);
     }
     return nullptr;
 }

--- a/bindings/ros/aditof_roscpp/src/pointcloud2_msg.cpp
+++ b/bindings/ros/aditof_roscpp/src/pointcloud2_msg.cpp
@@ -35,27 +35,28 @@ using namespace aditof;
 PointCloud2Msg::PointCloud2Msg() {}
 
 PointCloud2Msg::PointCloud2Msg(const std::shared_ptr<aditof::Camera> &camera,
-                               aditof::Frame *frame) {
-    FrameDataToMsg(camera, frame);
+                               aditof::Frame *frame, ros::Time tStamp) {
+    FrameDataToMsg(camera, frame, tStamp);
 }
 
 void PointCloud2Msg::FrameDataToMsg(const std::shared_ptr<Camera> &camera,
-                                    aditof::Frame *frame) {
+                                    aditof::Frame *frame, ros::Time tStamp) {
     FrameDetails fDetails;
     frame->getDetails(fDetails);
 
-    setMetadataMembers(fDetails.width, fDetails.height / 2);
+    setMetadataMembers(fDetails.width, fDetails.height / 2, tStamp);
     setDataMembers(camera, frame);
 }
 
-void PointCloud2Msg::setMetadataMembers(int width, int height) {
+void PointCloud2Msg::setMetadataMembers(int width, int height,
+                                        ros::Time tStamp) {
     sensor_msgs::PointCloud2Modifier modifier(msg);
     modifier.setPointCloud2Fields(4, "x", 1, sensor_msgs::PointField::FLOAT32,
                                   "y", 1, sensor_msgs::PointField::FLOAT32, "z",
                                   1, sensor_msgs::PointField::FLOAT32,
                                   "intensity", 1,
                                   sensor_msgs::PointField::UINT16);
-    msg.header.stamp = ros::Time::now();
+    msg.header.stamp = tStamp;
     msg.header.frame_id = "base_link";
 
     msg.width = width;


### PR DESCRIPTION
The camera node creates 4 messages based on the same frame, but each
message contains a different timestamp.This commit assures that all
4 messages have the same timestamp.

Signed-off-by: Andreea Sandulescu <andreea.sandulescu@analog.com>