### PR TITLE
Fix build for WITH_NETWORK=OFF

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -54,8 +54,6 @@ endif()
 file(GLOB PLATFORM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/${OS_SPECIFIC_DIR}/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/${OS_SPECIFIC_DIR}/*.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/*.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/*.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/${OS_SPECIFIC_DIR}/${TARGET_SPECIFIC_DIR}/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cameras/ad-96tof1-ebz/*.cpp
     ${CHICONY_SRC}
@@ -68,24 +66,30 @@ file(GLOB PLATFORM_HEADERS
     ${CHICONY_H}
 )
 
+file(GLOB NETWORK_SOURCES
+	${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/*.c
+)
+file(GLOB NETWORK_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/*.h
+)
+
 if ( ${OS_SPECIFIC_DIR} STREQUAL ${TARGET_STRING} )
     list(REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/local_device.cpp)
 endif()
 
-if ( NOT WITH_NETWORK )
-    list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/network.cpp)
-    list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/network.h)
+#if ( NOT WITH_NETWORK )
     list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ethernet_device.cpp)
     list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ethernet_device.h)
-    list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/device_enumerator_ethernet.cpp)
-    list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/connections/network/device_enumerator_ethernet.h)
-endif()
+#endif()
 
 # Create target and set properties
 add_library(${PROJECT_NAME} SHARED
     ${SOURCES}
     ${PLATFORM_SOURCES}
     ${PLATFORM_HEADERS}
+    $<$<BOOL:${WITH_NETWORK}>:${NETWORK_SOURCES}>
+    $<$<BOOL:${WITH_NETWORK}>:${NETWORK_HEADERS}>
     $<$<BOOL:${WITH_NETWORK}>:${PROTO_SRCS}>
     $<$<BOOL:${WITH_NETWORK}>:${PROTO_HDRS}>
 )

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -78,10 +78,10 @@ if ( ${OS_SPECIFIC_DIR} STREQUAL ${TARGET_STRING} )
     list(REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/local_device.cpp)
 endif()
 
-#if ( NOT WITH_NETWORK )
+if ( NOT WITH_NETWORK )
     list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ethernet_device.cpp)
     list (REMOVE_ITEM SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/ethernet_device.h)
-#endif()
+endif()
 
 # Create target and set properties
 add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
Fix build error when WITH_NETWORK=OFF - with the existing implementation only the files for network_device were being removed from the build list.