### PR TITLE
GCC 7.3.0 fix for usb_linux_utils.cpp

### DIFF
--- a/sdk/src/connections/usb/linux/usb_linux_utils.cpp
+++ b/sdk/src/connections/usb/linux/usb_linux_utils.cpp
@@ -131,7 +131,7 @@ int UsbLinuxUtils::uvcExUnitReadOnePacket(int fd, uint8_t selector,
 int UsbLinuxUtils::uvcExUnitReadBuffer(int fd, uint8_t selector,
                                        uint32_t address, uint8_t *data,
                                        uint32_t bufferLength) {
-    int ret;
+    int ret = 0;
     uint32_t readBytes = 0;
     uint32_t readLength = 0;
     uint32_t crtAddress = address;


### PR DESCRIPTION
usb_linux_utils.cpp fix int ret initialization on line 134, this cause error on Yocto GCC 7.3.0