### PR TITLE
Extend frame details

### DIFF
--- a/examples/aditof-demo/aditofdemorecorder.cpp
+++ b/examples/aditof-demo/aditofdemorecorder.cpp
@@ -35,7 +35,7 @@
 #include <string.h>
 
 AditofDemoRecorder::AditofDemoRecorder()
-    : m_frameDetails{0, 0, ""}, m_recordTreadStop(true),
+    : m_frameDetails{0, 0, 0, 0, ""}, m_recordTreadStop(true),
       m_playbackThreadStop(true), m_shouldReadNewFrame(true),
       m_playBackEofReached(false), m_numberOfFrames(0) {}
 

--- a/examples/aditof-demo/aditofdemoview.cpp
+++ b/examples/aditof-demo/aditofdemoview.cpp
@@ -913,7 +913,7 @@ void AdiTofDemoView::_displayDepthImage() {
         aditof::FrameDetails frameDetails;
         localFrame->getDetails(frameDetails);
 
-        int frameHeight = static_cast<int>(frameDetails.height) / 2;
+        int frameHeight = static_cast<int>(frameDetails.height);
         int frameWidth = static_cast<int>(frameDetails.width);
 
         m_depthImage = cv::Mat(frameHeight, frameWidth, CV_16UC1, data);
@@ -985,7 +985,7 @@ void AdiTofDemoView::_displayIrImage() {
         aditof::FrameDetails frameDetails;
         localFrame->getDetails(frameDetails);
 
-        int frameHeight = static_cast<int>(frameDetails.height) / 2;
+        int frameHeight = static_cast<int>(frameDetails.height);
         int frameWidth = static_cast<int>(frameDetails.width);
         int max_value_of_IR_pixel = (1 << m_ctrl->getbitCount()) - 1;
 
@@ -1014,7 +1014,7 @@ void AdiTofDemoView::_displayBlendedImage() {
     aditof::FrameDetails frameDetails;
     localFrame->getDetails(frameDetails);
 
-    int frameHeight = static_cast<int>(frameDetails.height) / 2;
+    int frameHeight = static_cast<int>(frameDetails.height);
     int frameWidth = static_cast<int>(frameDetails.width);
     int max_value_of_IR_pixel = (1 << m_ctrl->getbitCount()) - 1;
 

--- a/examples/imshow-jetson/main.cpp
+++ b/examples/imshow-jetson/main.cpp
@@ -48,7 +48,7 @@ aditof::Status fromFrameToDepthMat(aditof::Frame &frame, cv::Mat &mat) {
     aditof::FrameDetails frameDetails;
     frame.getDetails(frameDetails);
 
-    const int frameHeight = static_cast<int>(frameDetails.height) / 2;
+    const int frameHeight = static_cast<int>(frameDetails.height);
     const int frameWidth = static_cast<int>(frameDetails.width);
 
     uint16_t *depthData;

--- a/sdk/include/aditof/frame_definitions.h
+++ b/sdk/include/aditof/frame_definitions.h
@@ -65,6 +65,16 @@ struct FrameDetails {
     unsigned int height;
 
     /**
+     * @brief The width of the actual full frame.
+     */
+    unsigned int fullDataWidth;
+
+    /**
+     * @brief The height of the actual full frame.
+     */
+    unsigned int fullDataHeight;
+
+    /**
      * @brief The type of the frame. Can be one of the types provided by the
      * camera.
      */

--- a/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
@@ -359,10 +359,10 @@ aditof::Status Camera96Tof1::requestFrame(aditof::Frame *frame,
          m_details.frameType.type == "depth_only")) {
         m_calibration.calibrateDepth(frameDataLocation,
                                      m_details.frameType.width *
-                                         m_details.frameType.height / 2);
-        m_calibration.calibrateCameraGeometry(
-            frameDataLocation,
-            m_details.frameType.width * m_details.frameType.height / 2);
+                                         m_details.frameType.height);
+        m_calibration.calibrateCameraGeometry(frameDataLocation,
+                                              m_details.frameType.width *
+                                                  m_details.frameType.height);
     }
 
     return Status::OK;

--- a/sdk/src/connections/mipi/dragonboard/target_definitions.h
+++ b/sdk/src/connections/mipi/dragonboard/target_definitions.h
@@ -41,4 +41,6 @@ static const char *CAPTURE_DEVICE_NAME = "Qualcomm Camera Subsystem";
 
 static const char *TEMP_SENSOR_DEV_PATH = "/dev/i2c-1";
 
+static const int NUM_VIDEO_DEVS = 1;
+
 #endif // TARGET_DEFINITIONS_H

--- a/sdk/src/connections/mipi/jetson/target_definitions.h
+++ b/sdk/src/connections/mipi/jetson/target_definitions.h
@@ -44,4 +44,6 @@ static const char *TEMP_SENSOR_REPLACEMENT_DEV_PATH = "";
 
 static const char *CAPTURE_DEVICE_NAME = "vi-output, addi9036 6-0064";
 
+static const int NUM_VIDEO_DEVS = 1;
+
 #endif // TARGET_DEFINITIONS_H

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -515,7 +515,8 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
 
     unsigned int width;
     unsigned int height;
-    unsigned int buf_data_len;
+    unsigned int fullDataHeight = m_implData->frameDetails.fullDataHeight;
+    unsigned int fullDataWidth = m_implData->frameDetails.fullDataWidth;
     uint8_t *pdata;
 
     width = m_implData->frameDetails.width;
@@ -559,16 +560,16 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
         if (m_implData->frameDetails.type == "depth_only") {
             memcpy(buffer, pdata, buf.bytesused);
         } else if (m_implData->frameDetails.type == "ir_only") {
-            memcpy(buffer + (width * height) / 2, pdata, buf.bytesused);
+            memcpy(buffer + (width * height), pdata, buf.bytesused);
         } else {
-            uint32_t j = 0, j1 = width * height / 2;
-            for (uint32_t i = 0; i < height; i += 2) {
+            uint32_t j = 0, j1 = width * height;
+            for (uint32_t i = 0; i < fullDataHeight; i += 2) {
                 memcpy(buffer + j, pdata + i * width * 2, width * 2);
                 j += width;
                 memcpy(buffer + j1, pdata + (i + 1) * width * 2, width * 2);
                 j1 += width;
             }
-            for (uint32_t i = 0; i < width * height; i += 2) {
+            for (uint32_t i = 0; i < fullDataWidth * fullDataHeight; i += 2) {
                 buffer[i] =
                     ((buffer[i] & 0x00FF) << 4) | ((buffer[i]) & 0xF000) >> 12;
                 buffer[i + 1] = ((buffer[i + 1] & 0x00FF) << 4) |

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -300,16 +300,22 @@ LocalDevice::getAvailableFrameTypes(std::vector<aditof::FrameDetails> &types) {
 
     details.width = 640;
     details.height = 960;
+    details.fullDataWidth = details.width;
+    details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
     details.type = "depth_ir";
     types.push_back(details);
 
     details.width = 640;
     details.height = 960;
+    details.fullDataWidth = details.width;
+    details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
     details.type = "depth_only";
     types.push_back(details);
 
     details.width = 640;
     details.height = 960;
+    details.fullDataWidth = details.width;
+    details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
     details.type = "ir_only";
     types.push_back(details);
 

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -298,22 +298,22 @@ LocalDevice::getAvailableFrameTypes(std::vector<aditof::FrameDetails> &types) {
 
     FrameDetails details;
 
-    details.width = 640;
-    details.height = 960;
+    details.width = aditof::FRAME_WIDTH;
+    details.height = aditof::FRAME_HEIGHT;
     details.fullDataWidth = details.width;
     details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
     details.type = "depth_ir";
     types.push_back(details);
 
-    details.width = 640;
-    details.height = 960;
+    details.width = aditof::FRAME_WIDTH;
+    details.height = aditof::FRAME_HEIGHT;
     details.fullDataWidth = details.width;
     details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
     details.type = "depth_only";
     types.push_back(details);
 
-    details.width = 640;
-    details.height = 960;
+    details.width = aditof::FRAME_WIDTH;
+    details.height = aditof::FRAME_HEIGHT;
     details.fullDataWidth = details.width;
     details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
     details.type = "ir_only";

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -301,21 +301,21 @@ LocalDevice::getAvailableFrameTypes(std::vector<aditof::FrameDetails> &types) {
     details.width = aditof::FRAME_WIDTH;
     details.height = aditof::FRAME_HEIGHT;
     details.fullDataWidth = details.width;
-    details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
+    details.fullDataHeight = details.height * ((NUM_VIDEO_DEVS == 2) ? 1 : 2);
     details.type = "depth_ir";
     types.push_back(details);
 
     details.width = aditof::FRAME_WIDTH;
     details.height = aditof::FRAME_HEIGHT;
     details.fullDataWidth = details.width;
-    details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
+    details.fullDataHeight = details.height * ((NUM_VIDEO_DEVS == 2) ? 1 : 2);
     details.type = "depth_only";
     types.push_back(details);
 
     details.width = aditof::FRAME_WIDTH;
     details.height = aditof::FRAME_HEIGHT;
     details.fullDataWidth = details.width;
-    details.fullDataHeight = details.height * ((NUM_VIDEO_DEV == 2) ? 1 : 2);
+    details.fullDataHeight = details.height * ((NUM_VIDEO_DEVS == 2) ? 1 : 2);
     details.type = "ir_only";
     types.push_back(details);
 

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -515,12 +515,15 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
 
     unsigned int width;
     unsigned int height;
-    unsigned int fullDataHeight = m_implData->frameDetails.fullDataHeight;
-    unsigned int fullDataWidth = m_implData->frameDetails.fullDataWidth;
+    unsigned int fullDataWidth;
+    unsigned int fullDataHeight;
+    unsigned int buf_data_len;
     uint8_t *pdata;
 
     width = m_implData->frameDetails.width;
     height = m_implData->frameDetails.height;
+    fullDataWidth = m_implData->frameDetails.fullDataWidth;
+    fullDataHeight = m_implData->frameDetails.fullDataHeight;
 
     status = getInternalBuffer(&pdata, buf_data_len, buf);
     if (status != Status::OK) {
@@ -554,7 +557,7 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
                         ((((unsigned short)*(pdata + i + 2)) & 0x00F0) >> 4);
             j++;
         }
-    } else if (!isBufferPacked(buf, width, height)) {
+    } else if (!isBufferPacked(buf, fullDataWidth, fullDataHeight)) {
         // TODO: investigate optimizations for this (arm neon / 1024 bytes
         // chunks)
         if (m_implData->frameDetails.type == "depth_only") {

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -84,7 +84,7 @@ struct LocalDevice::ImplData {
 
     ImplData()
         : fd(-1), sfd(-1), videoBuffers(nullptr),
-          nVideoBuffers(0), frameDetails{0, 0, ""}, started(false) {}
+          nVideoBuffers(0), frameDetails{0, 0, 0, 0, ""}, started(false) {}
 };
 
 // TO DO: This exists in linux_utils.h which is not included on Dragoboard.
@@ -515,11 +515,15 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
 
     unsigned int width;
     unsigned int height;
+    unsigned int fullDataWidth;
+    unsigned int fullDataHeight;
     unsigned int buf_data_len;
     uint8_t *pdata;
 
     width = m_implData->frameDetails.width;
     height = m_implData->frameDetails.height;
+    fullDataWidth = m_implData->frameDetails.fullDataWidth;
+    fullDataHeight = m_implData->frameDetails.fullDataHeight;
 
     status = getInternalBuffer(&pdata, buf_data_len, buf);
     if (status != Status::OK) {
@@ -553,7 +557,7 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
                         ((((unsigned short)*(pdata + i + 2)) & 0x00F0) >> 4);
             j++;
         }
-    } else if (!isBufferPacked(buf, width, height)) {
+    } else if (!isBufferPacked(buf, fullDataWidth, fullDataHeight)) {
         // TODO: investigate optimizations for this (arm neon / 1024 bytes
         // chunks)
         if (m_implData->frameDetails.type == "depth_only") {
@@ -578,7 +582,7 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
     } else {
         // clang-format off
         uint16_t *depthPtr = buffer;
-        uint16_t *irPtr = buffer + (width * height) / 2;
+        uint16_t *irPtr = buffer + (width * height);
         unsigned int j = 0;
 
 	if (m_implData->frameDetails.type == "depth_only" ||

--- a/sdk/src/connections/mipi/local_device.cpp
+++ b/sdk/src/connections/mipi/local_device.cpp
@@ -515,15 +515,11 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
 
     unsigned int width;
     unsigned int height;
-    unsigned int fullDataWidth;
-    unsigned int fullDataHeight;
     unsigned int buf_data_len;
     uint8_t *pdata;
 
     width = m_implData->frameDetails.width;
     height = m_implData->frameDetails.height;
-    fullDataWidth = m_implData->frameDetails.fullDataWidth;
-    fullDataHeight = m_implData->frameDetails.fullDataHeight;
 
     status = getInternalBuffer(&pdata, buf_data_len, buf);
     if (status != Status::OK) {
@@ -539,7 +535,7 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
             bytesused = buf.bytesused;
         }
 
-        return bytesused == (width * height * 3 / 2);
+        return bytesused == (width * height * 3);
     };
 
     if ((width == 668)) {
@@ -557,7 +553,7 @@ aditof::Status LocalDevice::getFrame(uint16_t *buffer) {
                         ((((unsigned short)*(pdata + i + 2)) & 0x00F0) >> 4);
             j++;
         }
-    } else if (!isBufferPacked(buf, fullDataWidth, fullDataHeight)) {
+    } else if (!isBufferPacked(buf, width, height)) {
         // TODO: investigate optimizations for this (arm neon / 1024 bytes
         // chunks)
         if (m_implData->frameDetails.type == "depth_only") {
@@ -864,8 +860,8 @@ aditof::Status LocalDevice::getInternalBuffer(uint8_t **buffer,
                                               const struct v4l2_buffer &buf) {
 
     *buffer = static_cast<uint8_t *>(m_implData->videoBuffers[buf.index].start);
-    buf_data_len = m_implData->frameDetails.width *
-                   m_implData->frameDetails.height * 3 / 2;
+    buf_data_len =
+        m_implData->frameDetails.width * m_implData->frameDetails.height * 3;
 
     return aditof::Status::OK;
 }

--- a/sdk/src/connections/mipi/raspberrypi/target_definitions.h
+++ b/sdk/src/connections/mipi/raspberrypi/target_definitions.h
@@ -47,4 +47,6 @@ static const char *EEPROM_DEV_PATH = "/sys/bus/i2c/devices/0-0056/eeprom";
 
 static const char *CAPTURE_DEVICE_NAME = "unicam";
 
+static const int NUM_VIDEO_DEVS = 1;
+
 #endif // TARGET_DEFINITIONS_H

--- a/sdk/src/connections/usb/linux/usb_device_linux.cpp
+++ b/sdk/src/connections/usb/linux/usb_device_linux.cpp
@@ -170,8 +170,10 @@ UsbDevice::getAvailableFrameTypes(std::vector<aditof::FrameDetails> &types) {
     // Hardcored for now
     FrameDetails details;
 
-    details.width = 640;
-    details.height = 960;
+    details.width = aditof::USB_FRAME_WIDTH;
+    details.height = aditof::USB_FRAME_HEIGHT;
+    details.fullDataWidth = details.width;
+    details.fullDataHeight = details.height * 2; //TODO
     details.type = "depth_ir";
     types.push_back(details);
 
@@ -193,8 +195,8 @@ aditof::Status UsbDevice::setFrameType(const aditof::FrameDetails &details) {
     // Buggy driver paranoia.
     unsigned int min;
 
-    m_implData->fmt.fmt.pix.width = details.width;
-    m_implData->fmt.fmt.pix.height = details.height;
+    m_implData->fmt.fmt.pix.width = details.fullDataWidth;
+    m_implData->fmt.fmt.pix.height = details.fullDataHeight;
 
     min = m_implData->fmt.fmt.pix.width * 2;
     if (m_implData->fmt.fmt.pix.bytesperline < min)

--- a/sdk/src/connections/usb/windows/usb_device_windows.cpp
+++ b/sdk/src/connections/usb/windows/usb_device_windows.cpp
@@ -545,8 +545,8 @@ aditof::Status UsbDevice::setFrameType(const aditof::FrameDetails &details) {
     }
     VIDEOINFOHEADER *pVih = reinterpret_cast<VIDEOINFOHEADER *>(
         m_implData->handle.pAmMediaType->pbFormat);
-    HEADER(pVih)->biWidth = details.width;
-    HEADER(pVih)->biHeight = details.height;
+    HEADER(pVih)->biWidth = details.fullDataWidth;
+    HEADER(pVih)->biHeight = details.fullDataHeight;
 
     hr = m_implData->handle.streamConf->SetFormat(
         m_implData->handle.pAmMediaType);

--- a/sdk/src/connections/usb/windows/usb_device_windows.cpp
+++ b/sdk/src/connections/usb/windows/usb_device_windows.cpp
@@ -516,8 +516,10 @@ UsbDevice::getAvailableFrameTypes(std::vector<aditof::FrameDetails> &types) {
     // Hardcored for now
     FrameDetails details;
 
-    details.width = 640;
-    details.height = 960;
+    details.width = aditof::USB_FRAME_WIDTH;
+    details.height = aditof::USB_FRAME_HEIGHT;
+    details.fullDataWidth = details.width;
+    details.fullDataHeight = details.height * 2; //TODO
     details.type = "depth_ir";
     types.push_back(details);
 

--- a/sdk/src/frame_impl.cpp
+++ b/sdk/src/frame_impl.cpp
@@ -118,7 +118,7 @@ aditof::Status FrameImpl::getData(aditof::FrameDataType dataType,
 }
 
 void FrameImpl::allocFrameData(const aditof::FrameDetails &details) {
-    m_rawData = new uint16_t[details.width * details.height];
+    m_rawData = new uint16_t[details.fullDataWidth * details.fullDataHeight];
     m_depthData = m_rawData;
-    m_irData = m_rawData + (details.width * details.height) / 2;
+    m_irData = m_rawData + (details.width * details.height);
 }

--- a/sdk/src/frame_impl.cpp
+++ b/sdk/src/frame_impl.cpp
@@ -38,7 +38,7 @@
 #include <glog/logging.h>
 
 FrameImpl::FrameImpl()
-    : m_details{0, 0, ""}, m_depthData(nullptr), m_irData(nullptr),
+    : m_details{0, 0, 0, 0, ""}, m_depthData(nullptr), m_irData(nullptr),
       m_rawData(nullptr) {}
 
 FrameImpl::~FrameImpl() {

--- a/sdk/src/frame_impl.cpp
+++ b/sdk/src/frame_impl.cpp
@@ -51,7 +51,8 @@ FrameImpl::~FrameImpl() {
 FrameImpl::FrameImpl(const FrameImpl &op) {
     allocFrameData(op.m_details);
     memcpy(m_rawData, op.m_rawData,
-           sizeof(uint16_t) * op.m_details.width * op.m_details.height);
+           sizeof(uint16_t) * op.m_details.fullDataWidth *
+               op.m_details.fullDataHeight);
     m_details = op.m_details;
 }
 
@@ -63,7 +64,8 @@ FrameImpl &FrameImpl::operator=(const FrameImpl &op) {
         }
         allocFrameData(op.m_details);
         memcpy(m_rawData, op.m_rawData,
-               sizeof(uint16_t) * op.m_details.width * op.m_details.height);
+               sizeof(uint16_t) * op.m_details.fullDataWidth *
+                   op.m_details.fullDataHeight);
         m_details = op.m_details;
     }
 

--- a/sdk/src/local_device.h
+++ b/sdk/src/local_device.h
@@ -39,6 +39,11 @@
 
 struct v4l2_buffer;
 
+namespace aditof {
+static const unsigned int FRAME_WIDTH = 640;
+static const unsigned int FRAME_HEIGHT = 480;
+} // namespace aditof
+
 class LocalDevice : public aditof::DeviceInterface {
   public:
     LocalDevice(const aditof::DeviceConstructionData &data);

--- a/sdk/src/usb_device.h
+++ b/sdk/src/usb_device.h
@@ -36,6 +36,11 @@
 #include "aditof/device_interface.h"
 
 #include <memory>
+namespace aditof {
+//TODO this is temporary and should be removed imediately after these details are read from the hardware
+static const unsigned int USB_FRAME_WIDTH = 640;
+static const unsigned int USB_FRAME_HEIGHT = 480;
+} // namespace aditof
 
 class UsbDevice : public aditof::DeviceInterface {
   public:


### PR DESCRIPTION
Add `fullDataWidth` and `fullDataHeight` to `FrameDetails` and refactor the whole code (except uvc-gadget) in order to use the proper size depending on the needed values.
By this change there should be no more division / multiplication by 2 for frame size. Those operations were needed because on some platforms one frame is actually a container for 2 frames (IR and Depth). 