### PR TITLE
examples: aditof-demo: fix temperature readings

### DIFF
--- a/examples/aditof-demo/aditofdemocontroller.cpp
+++ b/examples/aditof-demo/aditofdemocontroller.cpp
@@ -200,7 +200,7 @@ std::pair<float, float> AdiTofDemoController::getTemperature() {
         tempSensors[0]->read(returnValue.first);
     }
     if (tempSensors.size() > 1) {
-        tempSensors[0]->read(returnValue.second);
+        tempSensors[1]->read(returnValue.second);
     }
 
     return returnValue;


### PR DESCRIPTION
This assumes that the target enumerates the sensors in the following order: AfeTemperatureSensor, LaserTemperatureSensor

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>