### PR TITLE
Avoid naming conflict between cmake define TARGET and enum element

### DIFF
--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -70,7 +70,7 @@ PYBIND11_MODULE(aditofpython, m) {
     py::enum_<aditof::ConnectionType>(m, "ConnectionType")
         .value("Usb", aditof::ConnectionType::USB)
         .value("Ethernet", aditof::ConnectionType::ETHERNET)
-        .value("local", aditof::ConnectionType::TARGET);
+        .value("local", aditof::ConnectionType::ON_TARGET);
 
     py::class_<aditof::IntrinsicParameters>(m, "IntrinsicParameters")
         .def(py::init<>())

--- a/sdk/include/aditof/connections.h
+++ b/sdk/include/aditof/connections.h
@@ -42,7 +42,7 @@ namespace aditof {
  * @brief Types of connections
  */
 enum class ConnectionType {
-    TARGET,   //!< on the target, direct sysfs access
+    ON_TARGET,   //!< on the target, direct sysfs access
     USB,      //!< connects to target via USB
     ETHERNET, //!< connects to target via Ethernet
 };

--- a/sdk/src/connections/mipi/toybrick/device_enumerator_toybrick.cpp
+++ b/sdk/src/connections/mipi/toybrick/device_enumerator_toybrick.cpp
@@ -75,7 +75,7 @@ aditof::Status DeviceEnumeratorImpl::findDevices(
     // TO DO: Don't guess the device, find a way to identify it so we are sure
     // we've got the right device and is compatible with the SDK
     DeviceConstructionData devData;
-    devData.connectionType = ConnectionType::TARGET;
+    devData.connectionType = ConnectionType::ON_TARGET;
     devData.driverPath = "/dev/video2;/dev/v4l-subdev0";
 
     //Check if EEPROM is availible

--- a/sdk/src/connections/target/addi9036_sensor.cpp
+++ b/sdk/src/connections/target/addi9036_sensor.cpp
@@ -105,7 +105,7 @@ Addi9036Sensor::Addi9036Sensor(const std::string &driverPath,
     m_implData->calibration_cache =
         std::unordered_map<std::string, CalibrationData>();
     m_sensorDetails.sensorType = aditof::SensorType::SENSOR_ADDI9036;
-    m_sensorDetails.connectionType = aditof::ConnectionType::TARGET;
+    m_sensorDetails.connectionType = aditof::ConnectionType::ON_TARGET;
 }
 
 Addi9036Sensor::~Addi9036Sensor() {

--- a/tools/eeprom-tool/cli_helper.cpp
+++ b/tools/eeprom-tool/cli_helper.cpp
@@ -82,7 +82,7 @@ Status parseArguments(int argc, char *argv[], CLIArguments &cliArguments) {
             cliArguments.isConnectionSpecifed = true;
             break;
         case 'm':
-            cliArguments.connectionType = ConnectionType::TARGET;
+            cliArguments.connectionType = ConnectionType::ON_TARGET;
             cliArguments.isConnectionSpecifed = true;
             break;
         case 'n':

--- a/tools/eeprom-tool/cli_helper.h
+++ b/tools/eeprom-tool/cli_helper.h
@@ -49,7 +49,7 @@ typedef struct {
     string path;
     string ip = "0.0.0.0";
     string eepromName = "";
-    ConnectionType connectionType = ConnectionType::TARGET;
+    ConnectionType connectionType = ConnectionType::ON_TARGET;
     ActionType actionType = UNKNOWN;
     bool isConnectionSpecifed = false;
 } CLIArguments;

--- a/tools/eeprom-tool/eeprom_tool.cpp
+++ b/tools/eeprom-tool/eeprom_tool.cpp
@@ -51,7 +51,7 @@ const aditof::SensorType sensorType = aditof::SensorType::SENSOR_CHICONY;
 const aditof::SensorType sensorType = aditof::SensorType::SENSOR_ADDI9036;
 #endif
 
-const std::string connectionTypeMapStr[] = {"TARGET", "USB", "ETHERNET"};
+const std::string connectionTypeMapStr[] = {"ON_TARGET", "USB", "ETHERNET"};
 
 EepromTool::EepromTool() {
     //TODO ??
@@ -80,7 +80,7 @@ aditof::Status EepromTool::setConnection(aditof::ConnectionType connectionType,
         enumerator =
             aditof::SensorEnumeratorFactory::buildUsbSensorEnumerator();
         break;
-    case aditof::ConnectionType::TARGET:
+    case aditof::ConnectionType::ON_TARGET:
         enumerator =
             aditof::SensorEnumeratorFactory::buildTargetSensorEnumerator();
         break;

--- a/tools/eeprom-tool/main.cpp
+++ b/tools/eeprom-tool/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
     }
     //if none is specified try local and usb
     else if (aditof::Status::OK == (status = controller.setConnection(
-                                        ConnectionType::TARGET, cliArguments.ip,
+                                        ConnectionType::ON_TARGET, cliArguments.ip,
                                         cliArguments.eepromName))) {
     } else if (aditof::Status::OK == (status = controller.setConnection(
                                           ConnectionType::USB, cliArguments.ip,

--- a/tools/eeprom-tool/tester.py
+++ b/tools/eeprom-tool/tester.py
@@ -14,7 +14,7 @@ BYTE_TO_ALTER_INDEX = 100
 
 class ConnectionType(Enum):
     USB = 1
-    TARGET = 2
+    ON_TARGET = 2
     ETHERNET = 3
 
 
@@ -28,7 +28,7 @@ class CommandType(Enum):
 def run_eeprom_tool(connection_type, command, path, ip=""):
     cmd = "./" + ls 
     connection_type_str = {ConnectionType.USB: "-u",
-                           ConnectionType.TARGET: "-m",
+                           ConnectionType.ON_TARGET: "-m",
                            ConnectionType.ETHERNET: "-e"}.get(connection_type, "-")
     ip_str = ip if connection_type == ConnectionType.ETHERNET else ""
     cmd_str = {CommandType.READ: "-r",
@@ -105,7 +105,7 @@ def test_readback(connection_type):
 
 
 def main():
-    test_readback(ConnectionType.TARGET)
+    test_readback(ConnectionType.ON_TARGET)
     test_readback(ConnectionType.USB)
 
 


### PR DESCRIPTION
Signed-off-by: Dan Nechita <dan.nechita@analog.com>