### PR TITLE
sdk: target: addi9036_sensor: fix empty driver sub path on rpi

### DIFF
--- a/sdk/src/connections/target/addi9036_sensor.cpp
+++ b/sdk/src/connections/target/addi9036_sensor.cpp
@@ -151,6 +151,11 @@ aditof::Status Addi9036Sensor::open() {
     const char *devName = m_driverPath.c_str();
     const char *subDevName = m_driverSubPath.c_str();
 
+    // On RPI the driver path and sub path are the same
+    if (!subDevName.length()) {
+        subDevName = m_driverPath.c_str();
+    }
+
     /* Open V4L2 device */
     if (stat(devName, &st) == -1) {
         LOG(WARNING) << "Cannot identify " << devName << "errno: " << errno


### PR DESCRIPTION
Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>