### PR TITLE
sdk: Fix sizes when deinterleaving frame obtained over network

### DIFF
--- a/sdk/src/connections/network/network_depth_sensor.cpp
+++ b/sdk/src/connections/network/network_depth_sensor.cpp
@@ -381,8 +381,8 @@ aditof::Status NetworkDepthSensor::getFrame(uint16_t *buffer) {
 
     aditof::deinterleave(net->recv_buff.bytes_payload(0).c_str(), buffer,
                          net->recv_buff.bytes_payload(0).length(),
-                         m_implData->frameDetails_cache.width,
-                         m_implData->frameDetails_cache.height);
+                         m_implData->frameDetails_cache.fullDataWidth,
+                         m_implData->frameDetails_cache.fullDataHeight);
 
     return status;
 }


### PR DESCRIPTION
It was observed that only half the IR images was being displayed.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>