### PR TITLE
Fixes for nx

### DIFF
--- a/sdk/src/cameras/ad-96tof1-ebz/calibration_96tof1.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/calibration_96tof1.cpp
@@ -361,7 +361,7 @@ setMode - Sets the mode to be used for depth calibration
 */
 aditof::Status Calibration96Tof1::setMode(const std::string &mode, int range,
                                           unsigned int frameWidth,
-                                          unsigned int frameheight) {
+                                          unsigned int frameHeight) {
     using namespace aditof;
 
     Status status = Status::OK;
@@ -392,7 +392,7 @@ aditof::Status Calibration96Tof1::setMode(const std::string &mode, int range,
                   << "    cx: " << cameraMatrix[2] << "\n"
                   << "    cy: " << cameraMatrix[5];
     }
-    buildGeometryCalibrationCache(cameraMatrix, frameWidth, frameheight);
+    buildGeometryCalibrationCache(cameraMatrix, frameWidth, frameHeight);
 
     return status;
 }

--- a/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
@@ -249,7 +249,7 @@ aditof::Status Camera96Tof1::setMode(const std::string &mode,
     // Register set for VC ID. Set Depth on VC=0 and IR on VC=1
     uint16_t afeRegsAddr[5] = {0x4001, 0x7c22, 0xc3dc, 0x4001, 0x7c22};
     uint16_t afeRegsVal[5] = {0x0006, 0x0004, 0xe4, 0x0007, 0x0004};
-    m_device->writeAfeRegisters(afeRegsAddr, afeRegsVal, 5);
+    m_depthSensor->writeAfeRegisters(afeRegsAddr, afeRegsVal, 5);
 #endif
     // register writes for enabling only one video stream (depth/ ir)
     // must be done here after programming the camera in order for them to

--- a/sdk/src/frame_impl.cpp
+++ b/sdk/src/frame_impl.cpp
@@ -120,7 +120,7 @@ aditof::Status FrameImpl::getData(aditof::FrameDataType dataType,
 }
 
 void FrameImpl::allocFrameData(const aditof::FrameDetails &details) {
-    m_fullData = new uint16_t[details.fullDataWidth * details.fullDataHeight];
+    m_fullData = new uint16_t[details.width * details.height * 2];
     m_depthData = m_fullData;
     m_irData = m_fullData + (details.width * details.height);
 }


### PR DESCRIPTION
Fixes: 
- Fix buffer size allocation for frame
- Replace deprecated `device` usage with `depthSensor`
- Naming convention fix method argument

