### PR TITLE
Chicony fixes

### DIFF
--- a/sdk/src/cameras/chicony-006/calibration_chicony_006.cpp
+++ b/sdk/src/cameras/chicony-006/calibration_chicony_006.cpp
@@ -106,7 +106,7 @@ aditof::Status CalibrationChicony006::initialize(
     aditof::Status status = Status::OK;
 
     m_sensor = device;
-    m_eeprom = m_eeprom;
+    m_eeprom = eeprom;
 
     CEEPROM.ReadEEPROMVersion(EEPROM_V_data, EEPROM_V_size);
 

--- a/sdk/src/cameras/chicony-006/calibration_chicony_006.cpp
+++ b/sdk/src/cameras/chicony-006/calibration_chicony_006.cpp
@@ -99,13 +99,14 @@ aditof::Status CalibrationChicony006::SetEEPROMData_1(uint16_t Gdata[][2],
 }
 
 aditof::Status CalibrationChicony006::initialize(
-    std::shared_ptr<aditof::DepthSensorInterface> device,
+    std::shared_ptr<aditof::DepthSensorInterface> sensor,
+
     std::shared_ptr<aditof::StorageInterface> eeprom) {
     using namespace aditof;
 
     aditof::Status status = Status::OK;
 
-    m_sensor = device;
+    m_sensor = sensor;
     m_eeprom = eeprom;
 
     CEEPROM.ReadEEPROMVersion(EEPROM_V_data, EEPROM_V_size);
@@ -199,7 +200,6 @@ aditof::Status CalibrationChicony006::close() {
     sensorPowerDown();
 
     return Status::OK;
-    ;
 }
 
 //! setMode - Sets the mode to be used for depth calibration

--- a/sdk/src/system_impl.cpp
+++ b/sdk/src/system_impl.cpp
@@ -79,42 +79,8 @@ buildCameras(std::unique_ptr<SensorEnumeratorInterface> enumerator) {
                     << " while looking for storage for camera AD-96TOF1-EBZ";
                 break;
             }
-
-            // Look for AFE temperature sensor
-            auto afeTempSensorIter = std::find_if(
-                temperatureSensors.begin(), temperatureSensors.end(),
-                [](std::shared_ptr<TemperatureSensorInterface> tSensor) {
-                    std::string name;
-                    tSensor->getName(name);
-                    return name == skAfeTempSensor;
-                });
-            if (afeTempSensorIter == temperatureSensors.end()) {
-                DLOG(INFO) << "Could not find " << skAfeTempSensor
-                           << " while looking for temperature sensors for "
-                              "camera AD-96TOF1-EBZ";
-                break;
-            }
-
-            // Look for laser temperature sensor
-            auto laserTempSensorIter = std::find_if(
-                temperatureSensors.begin(), temperatureSensors.end(),
-                [](std::shared_ptr<TemperatureSensorInterface> tSensor) {
-                    std::string name;
-                    tSensor->getName(name);
-                    return name == skLaserTempSensor;
-                });
-            if (laserTempSensorIter == temperatureSensors.end()) {
-                DLOG(INFO) << "Could not find " << skLaserTempSensor
-                           << " while looking for temperature sensors for "
-                              "camera AD-96TOF1-EBZ";
-                break;
-            }
-
             std::shared_ptr<StorageInterface> eeprom = *eeprom_iter;
-            std::shared_ptr<TemperatureSensorInterface> afeTempSensor =
-                *afeTempSensorIter;
-            std::shared_ptr<TemperatureSensorInterface> laserTempSensor =
-                *laserTempSensorIter;
+
 #if defined CHICONY_006 || defined FXTOF1
 
             // Look for temperature sensor
@@ -143,6 +109,40 @@ buildCameras(std::unique_ptr<SensorEnumeratorInterface> enumerator) {
                 std::make_shared<CameraFxTof1>(dSensor, eeprom, tempSensor);
 #endif
 #else
+            // Look for AFE temperature sensor
+            auto afeTempSensorIter = std::find_if(
+                temperatureSensors.begin(), temperatureSensors.end(),
+                [](std::shared_ptr<TemperatureSensorInterface> tSensor) {
+                    std::string name;
+                    tSensor->getName(name);
+                    return name == skAfeTempSensor;
+                });
+            if (afeTempSensorIter == temperatureSensors.end()) {
+                DLOG(INFO) << "Could not find " << skAfeTempSensor
+                           << " while looking for temperature sensors for "
+                              "camera AD-96TOF1-EBZ";
+                break;
+            }
+            std::shared_ptr<TemperatureSensorInterface> afeTempSensor =
+                *afeTempSensorIter;
+
+            // Look for laser temperature sensor
+            auto laserTempSensorIter = std::find_if(
+                temperatureSensors.begin(), temperatureSensors.end(),
+                [](std::shared_ptr<TemperatureSensorInterface> tSensor) {
+                    std::string name;
+                    tSensor->getName(name);
+                    return name == skLaserTempSensor;
+                });
+            if (laserTempSensorIter == temperatureSensors.end()) {
+                DLOG(INFO) << "Could not find " << skLaserTempSensor
+                           << " while looking for temperature sensors for "
+                              "camera AD-96TOF1-EBZ";
+                break;
+            }
+            std::shared_ptr<TemperatureSensorInterface> laserTempSensor =
+                *laserTempSensorIter;
+
             std::shared_ptr<Camera> camera = std::make_shared<Camera96Tof1>(
                 dSensor, eeprom, afeTempSensor, laserTempSensor);
 #endif


### PR DESCRIPTION
Fixes:

- Move search of AfeTempSensor and LaserTempSensor in the macro else-branch that runs if neither Chicony nor FXTOF1 are selected (as those sensors do not exist in the case of these cameras)
- Fix chicony calibration constructor by copying the eeprom pointer into the local member
- Rename deprecated `device` to `sensor`
- Remove uneeded `;`