### PR TITLE
sdcard: Fix paths for opencv pkconfig file

### DIFF
--- a/sdcard-images-utils/dragonboard410c/utils/chroot.sh
+++ b/sdcard-images-utils/dragonboard410c/utils/chroot.sh
@@ -18,6 +18,8 @@ cd /home/linaro/workspace/github
 wget http://swdownloads.analog.com/cse/aditof/deps-dragonboard.tar.xz
 tar -xf deps-dragonboard.tar.xz
 
+sed -i 's+/home/linaro/workspace/github/aditof_sdk/deps/installed/opencv-3.4.1+/usr/local+g' /home/linaro/workspace/github/deps/opencv-3.4.1/lib/pkgconfig/opencv.pc
+
 cp -r /home/linaro/workspace/github/deps/opencv-3.4.1/* /usr/local/
 cp -r /home/linaro/workspace/github/deps/glog/* /usr/local/
 cp -r /home/linaro/workspace/github/deps/protobuf/* /usr/local/
@@ -35,6 +37,8 @@ cp -r /home/linaro/workspace/github/deps/chromium /home/linaro/.config/
 
 sudo rm -rf /home/linaro/workspace/github/deps
 sudo rm -rf /home/linaro/workspace/github/deps-dragonboard.tar.xz
+
+sudo ldconfig
 
 git clone --branch $1 https://github.com/analogdevicesinc/aditof_sdk
 


### PR DESCRIPTION
This will make sure that opencv examples and python calibration tools see the opencv which is installed at /usr/local.

Also, ldconfig is required for the new paths to apply.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>