### PR TITLE
Remove un-needed write to EEPROM for AD-96TOF1-EBZ

### DIFF
--- a/sdk/src/cameras/ad-96tof1-ebz/calibration_96tof1.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/calibration_96tof1.cpp
@@ -158,8 +158,6 @@ aditof::Status Calibration96Tof1::readCalMap(
     uint32_t j = 0;
     float key;
 
-    eeprom->write(EEPROM_SIZE - 5, (uint8_t *)&read_size, 4);
-
     eeprom->read(0, (uint8_t *)&read_size, 4);
     LOG(INFO) << "EEPROM calibration data size " << read_size << " bytes";
 
@@ -312,8 +310,8 @@ aditof::Status Calibration96Tof1::getGainOffset(const std::string &mode,
 //! getIntrinsic - Get the geometric camera calibration
 /*!
 getIntrinsic - Get the geometric camera clibration
-\param key - Specifies which calibration values to get: 
-             intrinsincs or distortion coefficients 
+\param key - Specifies which calibration values to get:
+             intrinsincs or distortion coefficients
 \param data - Buffer to store the returned data
 */
 aditof::Status Calibration96Tof1::getIntrinsic(float key,

--- a/tools/eeprom-tool/cam96tof1_eeprom.cpp
+++ b/tools/eeprom-tool/cam96tof1_eeprom.cpp
@@ -51,9 +51,6 @@ aditof::Status Camera96Tof1Eeprom::read(std::vector<uint8_t> &data) {
     m_eeprom->getName(eepromName);
     eepromSize = EEPROMS.at(eepromName).size;
 
-    //mistery
-    m_eeprom->write(eepromSize - 5, (uint8_t *)&read_size, 4);
-
     //read size
     m_eeprom->read((uint32_t)0, (uint8_t *)&read_size, (size_t)4);
     LOG(INFO) << "EEPROM calibration data size " << read_size << " bytes";


### PR DESCRIPTION
Writing value 100 near the end of the EEPROM doesn't help reading the size of the EEPROM. So we remove the write operation.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>