### PR TITLE
sdk: camera: xavier agx: Update subdev name for L4T 32.5

### DIFF
--- a/sdk/src/cameras/ad-96tof1-ebz/xavier_agx/sensor_enumerator_xavier.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/xavier_agx/sensor_enumerator_xavier.cpp
@@ -53,7 +53,7 @@ Status TargetSensorEnumerator::searchSensors() {
     SensorInfo sInfo;
     sInfo.sensorType = SensorType::SENSOR_ADDI9036;
     sInfo.driverPath = "/dev/video0|/dev/video1";
-    sInfo.subDevPath = "/dev/v4l-subdev0|/dev/v4l-subdev2";
+    sInfo.subDevPath = "/dev/v4l-subdev2|/dev/v4l-subdev3";
     sInfo.captureDev = CAPTURE_DEVICE_NAME;
     m_sensorsInfo.emplace_back(sInfo);
 


### PR DESCRIPTION
In L4T 32.5 kernel update the video subdevs enumeration order was
changed. Update SDK accordingly.

Signed-off-by: btogorean <bogdan.togorean@analog.com>