### PR TITLE
sdk: Add 'attributes' to a frame

### DIFF
--- a/sdk/include/aditof/frame.h
+++ b/sdk/include/aditof/frame.h
@@ -93,12 +93,47 @@ class SDK_API Frame {
     Status getDetails(FrameDetails &details) const;
 
     /**
+     * @brief Gets details of a type of data within the frame
+     * @param dataType
+     * @param[out] details
+     * @return Status
+     */
+    Status getDataDetails(const std::string &dataType,
+                          FrameDataDetails &details) const;
+
+    /**
      * @brief Gets the address where the specified data is being stored
      * @param dataType
      * @param[out] dataPtr
      * @return Status
      */
-    Status getData(FrameDataType dataType, uint16_t **dataPtr);
+    Status getData(const std::string &dataType, uint16_t **dataPtr);
+
+    /**
+     * @brief Gets the frames's list of attributes
+     * @param[out] attributes
+     * @return Status
+     */
+    virtual Status
+    getAvailableAttributes(std::vector<std::string> &attributes) const = 0;
+
+    /**
+     * @brief Sets a specific frame attribute
+     * @param[in] attribute - Attribute name
+     * @param[in] value - Attribute value
+     * @return Status
+     */
+    virtual Status setAttribute(const std::string &attribute,
+                                const std::string &value) = 0;
+
+    /**
+     * @brief Gets the value of a specific frame attribute
+     * @param[in] attribute - Attribute name
+     * @param[out] value - Attribute value
+     * @return Status
+     */
+    virtual Status getAttribute(const std::string &attribute,
+                                std::string &value) const = 0;
 
   private:
     std::unique_ptr<FrameImpl> m_impl;

--- a/sdk/include/aditof/frame_definitions.h
+++ b/sdk/include/aditof/frame_definitions.h
@@ -33,6 +33,7 @@
 #define FRAME_DEFINITIONS_H
 
 #include <string>
+#include <vector>
 
 /**
  * @brief Namespace aditof
@@ -40,13 +41,25 @@
 namespace aditof {
 
 /**
- * @enum FrameDataType
- * @brief Types of data that a frame can contain
+ * @struct FrameDataDetails
+ * @brief Describes the properties of a data that embedded within the frame
  */
-enum class FrameDataType {
-    FULL_DATA, //!< Raw information
-    DEPTH,     //!< Depth information
-    IR,        //!< Infrared information
+struct FrameDataDetails {
+    /**
+     * @brief The type of data that can be found in a frame. For example it
+     * could be depth data or IR data, etc.
+     */
+    std::string type;
+
+    /**
+     * @brief The width of the frame data
+     */
+    unsigned int width;
+
+    /**
+     * @brief The height of the frame data
+     */
+    unsigned int height;
 };
 
 /**
@@ -55,30 +68,31 @@ enum class FrameDataType {
  */
 struct FrameDetails {
     /**
-     * @brief The width of the frame.
-     */
-    unsigned int width;
-
-    /**
-     * @brief The height of the frame.
-     */
-    unsigned int height;
-
-    /**
-     * @brief The width of the actual full frame.
-     */
-    unsigned int fullDataWidth;
-
-    /**
-     * @brief The height of the actual full frame.
-     */
-    unsigned int fullDataHeight;
-
-    /**
      * @brief The type of the frame. Can be one of the types provided by the
      * camera.
      */
     std::string type;
+
+    /**
+     * @brief A frame can have multiple types of data. For example it could
+     * hold data about depth and/or data about IR.
+     */
+    std::vector<FrameDataDetails> dataDetails;
+
+    /**
+     * @brief The width of the entire frame
+     */
+    unsigned int width;
+
+    /**
+     * @brief The height of the entire frame
+     */
+    unsigned int height;
+
+    /**
+     * @brief The mode the camera was set when the frame was captured.
+     */
+    std::string cameraMode;
 };
 
 } // namespace aditof

--- a/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
@@ -428,7 +428,7 @@ aditof::Status Camera96Tof1::requestFrame(aditof::Frame *frame,
     }
 
     uint16_t *frameDataLocation;
-    frame->getData(FrameDataType::FULL_DATA, &frameDataLocation);
+    frame->getData("allData", &frameDataLocation);
 
     status = m_depthSensor->getFrame(frameDataLocation);
     if (status != Status::OK) {

--- a/sdk/src/cameras/ad-fxtof1-ebz/camera_fxtof1.cpp
+++ b/sdk/src/cameras/ad-fxtof1-ebz/camera_fxtof1.cpp
@@ -359,7 +359,7 @@ aditof::Status CameraFxTof1::requestFrame(aditof::Frame *frame,
     }
 
     uint16_t *frameDataLocation;
-    frame->getData(FrameDataType::FULL_DATA, &frameDataLocation);
+    frame->getData("allData", &frameDataLocation);
 
     status = m_depthSensor->getFrame(frameDataLocation);
     if (status != Status::OK) {

--- a/sdk/src/cameras/chicony-006/camera_chicony_006.cpp
+++ b/sdk/src/cameras/chicony-006/camera_chicony_006.cpp
@@ -336,7 +336,7 @@ aditof::Status CameraChicony::requestFrame(aditof::Frame *frame,
     }
 
     uint16_t *frameDataLocation;
-    frame->getData(FrameDataType::FULL_DATA, &frameDataLocation);
+    frame->getData(allData, &frameDataLocation);
 
     status = m_sensor->getFrame(frameDataLocation);
     if (status != Status::OK) {

--- a/sdk/src/frame.cpp
+++ b/sdk/src/frame.cpp
@@ -60,8 +60,28 @@ Status Frame::getDetails(FrameDetails &details) const {
     return m_impl->getDetails(details);
 }
 
-Status Frame::getData(FrameDataType dataType, uint16_t **dataPtr) {
+Status Frame::getDataDetails(const std::string &dataType,
+                             FrameDataDetails &details) const {
+    return m_impl->getDataDetails(dataType, details);
+}
+
+Status Frame::getData(const std::string &dataType, uint16_t **dataPtr) {
     return m_impl->getData(dataType, dataPtr);
+}
+
+Status
+Frame::getAvailableAttributes(std::vector<std::string> &attributes) const {
+    return m_impl->getAvailableAttributes(attributes);
+}
+
+Status Frame::setAttribute(const std::string &attribute,
+                           const std::string &value) {
+    return m_impl->setAttribute(attribute, value);
+}
+
+Status Frame::getAttribute(const std::string &attribute,
+                           std::string &value) const {
+    return m_impl->getAttribute(attribute, value);
 }
 
 } // namespace aditof

--- a/sdk/src/frame_impl.h
+++ b/sdk/src/frame_impl.h
@@ -36,6 +36,7 @@
 #include <aditof/status_definitions.h>
 
 #include <stdint.h>
+#include <unordered_map>
 
 class FrameImpl {
   public:
@@ -47,16 +48,23 @@ class FrameImpl {
   public: // from TofFrame
     aditof::Status setDetails(const aditof::FrameDetails &details);
     aditof::Status getDetails(aditof::FrameDetails &details) const;
-    aditof::Status getData(aditof::FrameDataType dataType, uint16_t **dataPtr);
+    aditof::Status getDataDetails(const std::string dataType,
+                                  aditof::FrameDataDetails &details) const;
+    aditof::Status getData(const std::string &dataType, uint16_t **dataPtr);
+    aditof::Status
+    getAvailableAttributes(std::vector<std::string> &attributes) const;
+    aditof::Status setAttribute(const std::string &attribute,
+                                const std::string &value);
+    aditof::Status getAttribute(const std::string &attribute,
+                                std::string &value) const;
 
   private:
     void allocFrameData(const aditof::FrameDetails &details);
 
   private:
     aditof::FrameDetails m_details;
-    uint16_t *m_depthData;
-    uint16_t *m_irData;
-    uint16_t *m_fullData;
+    uint16_t *m_allData;
+    std::unordered_map<std::string, uint16_t *> m_dataLocations;
 };
 
 #endif // FRAME_IMPL


### PR DESCRIPTION
Different cameras can stream different types of frames. Attributes can
be specific to a type of frame. Attributes are identified by name (string)
and have a value (also string).

This allows for keeping the same API for frames that are somehow
different but not fundamentally different.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>