### PR TITLE
sdk/include: Remove windows warning warning C4251

### DIFF
--- a/sdk/include/aditof/frame.h
+++ b/sdk/include/aditof/frame.h
@@ -46,36 +46,37 @@ namespace aditof {
  * @class Frame
  * @brief Frame of a camera.
  */
-class SDK_API Frame {
+class Frame {
   public:
     /**
      * @brief Constructor
      */
-    Frame();
+    SDK_API Frame();
 
     /**
      * @brief Destructor
      */
-    ~Frame();
+    SDK_API ~Frame();
 
     /**
      * @brief Copy constructor
      */
-    Frame(const Frame &op);
+    SDK_API Frame(const Frame &op);
 
     /**
      * @brief Copy assignment
      */
-    Frame &operator=(const Frame &op);
+    SDK_API Frame &operator=(const Frame &op);
 
     /**
      * @brief Move constructor
      */
-    Frame(Frame &&) noexcept;
+    SDK_API Frame(Frame &&) noexcept;
+
     /**
      * @brief Move assignment
      */
-    Frame &operator=(Frame &&) noexcept;
+    SDK_API Frame &operator=(Frame &&) noexcept;
 
   public:
     /**
@@ -83,14 +84,14 @@ class SDK_API Frame {
      * @param details
      * @return Status
      */
-    Status setDetails(const FrameDetails &details);
+    SDK_API Status setDetails(const FrameDetails &details);
 
     /**
      * @brief Gets the current details of the frame
      * @param[out] details
      * @return Status
      */
-    Status getDetails(FrameDetails &details) const;
+    SDK_API Status getDetails(FrameDetails &details) const;
 
     /**
      * @brief Gets the address where the specified data is being stored
@@ -98,7 +99,7 @@ class SDK_API Frame {
      * @param[out] dataPtr
      * @return Status
      */
-    Status getData(FrameDataType dataType, uint16_t **dataPtr);
+    SDK_API Status getData(FrameDataType dataType, uint16_t **dataPtr);
 
   private:
     std::unique_ptr<FrameImpl> m_impl;

--- a/sdk/include/aditof/system.h
+++ b/sdk/include/aditof/system.h
@@ -49,28 +49,28 @@ class Camera;
  * @class System
  * @brief The TOF system that manages the cameras.
  */
-class SDK_API System {
+class System {
   public:
     /**
      * @brief Constructor
      */
-    System();
+    SDK_API System();
 
     /**
      * @brief Destructor
      */
-    ~System();
+    SDK_API ~System();
 
     // Make System movable and non-copyable
     /**
      * @brief Move constructor
      */
-    System(System &&op) noexcept;
+    SDK_API System(System &&op) noexcept;
 
     /**
      * @brief Move assignment
      */
-    System &operator=(System &&op) noexcept;
+    SDK_API System &operator=(System &&op) noexcept;
 
   public:
     /**
@@ -79,7 +79,7 @@ class SDK_API System {
      * @param[out] cameraList - A container to be set with the available cameras
      * @return Status
      */
-    Status
+    SDK_API Status
     getCameraList(std::vector<std::shared_ptr<Camera>> &cameraList) const;
 
     /**
@@ -89,8 +89,9 @@ class SDK_API System {
      * @param ip - The IP of the remote target
      * @return Status
      */
-    Status getCameraListAtIp(std::vector<std::shared_ptr<Camera>> &cameraList,
-                             const std::string &ip) const;
+    SDK_API Status
+    getCameraListAtIp(std::vector<std::shared_ptr<Camera>> &cameraList,
+                      const std::string &ip) const;
 
   private:
     std::unique_ptr<SystemImpl> m_impl;


### PR DESCRIPTION
warning C4251: 'aditof::System::m_impl': class
'std::unique_ptr<SystemImpl,std::default_delete<SystemImpl>>' needs to
have dll-interface to be used by clients of class 'aditof::System'

warning C4251: 'aditof::Frame::m_impl': class
'std::unique_ptr<FrameImpl,std::default_delete<FrameImpl>>' needs to
have dll-interface to be used by clients of class 'aditof::Frame'

Signed-off-by: Dan Nechita <dan.nechita@analog.com>