### PR TITLE
misc: kernel_src: addi9036.c: Downgrade I2C error message

### DIFF
--- a/misc/nvidia/jetson/kernel_src/kernel/kernel-4.9/drivers/media/i2c/addi9036.c
+++ b/misc/nvidia/jetson/kernel_src/kernel/kernel-4.9/drivers/media/i2c/addi9036.c
@@ -115,7 +115,7 @@ static int addi9036_set_chip_config(struct v4l2_ctrl *ctrl)
 	for (index = 0; index < ctrl->elems; index += 2) {
 		ret = regmap_write(priv->regmap, *reg, *val);
 		if (ret)
-			dev_warn(dev,
+			dev_dbg(dev,
 				 "could not write to register %x\n", *reg);
 
 		reg += 2;


### PR DESCRIPTION
Do not print in DMESG error message for I2C write failure.
Messages can still be enabled using dynamic_debug

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>