### PR TITLE
examples/aditof-demo: Fix memory leak by learing queue with frames

### DIFF
--- a/examples/aditof-demo/aditofdemocontroller.cpp
+++ b/examples/aditof-demo/aditofdemocontroller.cpp
@@ -134,6 +134,7 @@ void AdiTofDemoController::stopCapture() {
     if (m_workerThread.joinable()) {
         m_workerThread.join();
     }
+    m_queue.clear();
 }
 
 std::string AdiTofDemoController::getMode() const {

--- a/examples/aditof-demo/safequeue.h
+++ b/examples/aditof-demo/safequeue.h
@@ -59,6 +59,8 @@ class SafeQueue {
 
     bool empty() const { return m_queue.empty(); }
 
+    void clear() { m_queue = {}; }
+
   private:
     std::queue<T> m_queue;
     std::mutex m_mutex;


### PR DESCRIPTION
What was happening was that after clicking the stop button and then
click start again, the memory usage (on Windows) was increasing by 1.4
GB. And this could go on for each stop->start iteration.
The fix is to clear the queue with captured frames when stopping the
stream capture. Otherwise the next captuing will start with a large
queue (thinking it's empty) and appending new frames to that.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>