### PR TITLE
misc: jetson: drivers: addi9036: Fix regmap read allowed range

### DIFF
--- a/misc/nvidia/jetson/kernel_src/kernel/kernel-4.9/drivers/media/i2c/addi9036.c
+++ b/misc/nvidia/jetson/kernel_src/kernel/kernel-4.9/drivers/media/i2c/addi9036.c
@@ -50,7 +50,7 @@ struct addi9036 {
 static bool addi9306_readable_register(struct device *dev, unsigned int reg)
 {
 	if (((reg >= 0x4000) && (reg <= 0x6FFF)) ||
-	    ((reg >= 0x7C00) && (reg <= 0x7C1F)) ||
+	    ((reg >= 0x7C00) && (reg <= 0x7C9F)) ||
 	    ((reg >= 0x7CE0) && (reg <= 0x7FFF)) ||
 	    ((reg >= 0xC000) && (reg <= 0xC0FF)) ||
 	    ((reg >= 0xC110) && (reg <= 0xC200)) ||


### PR DESCRIPTION
Write only start at 0x7CA0 according to datasheet so fix allowed range

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>