### PR TITLE
ROS: camera_node corrections

### DIFF
--- a/bindings/ros/aditof_roscpp/cfg/Aditof_roscpp.cfg
+++ b/bindings/ros/aditof_roscpp/cfg/Aditof_roscpp.cfg
@@ -9,11 +9,16 @@ near_var = gen.const("near",  int_t, 0, "Near mode")
 med_var = gen.const("medium", int_t, 1, "Medium mode")
 far_var = gen.const("far",    int_t, 2, "Far mode")
 
-revb_var = gen.const("RevB",  int_t, 0, "RevB")
-revc_var = gen.const("RevC",  int_t, 1, "RevC")
+reva_var = gen.const("RevA",  int_t, 0, "RevA")
+revb_var = gen.const("RevB",  int_t, 1, "RevB")
+revc_var = gen.const("RevC",  int_t, 2, "RevC")
+
+mono16_var = gen.const("MONO16", int_t, 0, "MONO16")
+rgba8_var = gen.const("RGBA8", int_t, 1, "RGBA8")
 
 mode_enum = gen.enum([near_var, med_var, far_var], "Camera mode options")
-rev_enum = gen.enum([revb_var, revc_var], "Camera revision options")
+rev_enum = gen.enum([reva_var, revb_var, revc_var], "Camera revision options")
+format_enum = gen.enum([mono16_var, rgba8_var],"Depth data format options")
 
 group_tof = gen.add_group("Camera ToF", type="hide", state=True)
 
@@ -22,7 +27,9 @@ group_tof.add("mode", int_t, 0, "Camera mode", 1, 0, 2,
               edit_method=mode_enum)
 group1a = group_tof.add_group("Noise reduction", type="hide", state = True)
 group1a.add("threshold", int_t, 0, "Noise reduction threshold", 0, 0, 16383)
-group_tof.add("revision", int_t, 0, "Camera revision", 1, 0, 1,
+group_tof.add("revision", int_t, 0, "Camera revision", 2, 0, 1,
                edit_method=rev_enum)
+group_tof.add("depth_data_format", int_t, 0, "Depth data format", 1, 0, 1,
+              edit_method=format_enum)
 
 exit(gen.generate(PACKAGE, "aditof_roscpp", "Aditof_roscpp"))

--- a/bindings/ros/aditof_roscpp/include/aditof_roscpp/depthImage_msg.h
+++ b/bindings/ros/aditof_roscpp/include/aditof_roscpp/depthImage_msg.h
@@ -107,8 +107,12 @@ class DepthImageMsg : public AditofSensorMsg {
      */
     void publishMsg(const ros::Publisher &pub);
 
+    void setDepthDataFormat(int value);
+    int getDepthDataFormat();
+
   private:
     DepthImageMsg();
+    int m_depthDataFormat; //MONO16 - 0, RGBA8 - 1
 };
 
 #endif // DEPTHIMAGE_MSG_H

--- a/bindings/ros/aditof_roscpp/src/camera_node.cpp
+++ b/bindings/ros/aditof_roscpp/src/camera_node.cpp
@@ -74,9 +74,9 @@ void callback(aditof_roscpp::Aditof_roscppConfig &config, uint32_t level,
     case 2:
         setCameraRevision(camera, "RevC");
         break;
-    }
+    }*/
     setIrGammaCorrection(camera, config.ir_gamma);
-*/
+
     switch (config.depth_data_format) { //MONO16 - 0, RGBA8 - 1
     case 0:
         depthImgMsg->setDepthDataFormat(0);


### PR DESCRIPTION
ROS binding: added dropdown menu for depth data format between (MONO16 and RGBA8)

Signed-off-by: rbudai98 <robert.budai@analog.com>