### PR TITLE
sdk: Add option to enable IR distorsion correctio

### DIFF
--- a/sdk/src/cameras/3d-smart-camera/camera_3d_smart.cpp
+++ b/sdk/src/cameras/3d-smart-camera/camera_3d_smart.cpp
@@ -60,13 +60,10 @@ static const std::string skCustomMode = "custom";
 
 static const std::vector<std::string> availableControls = {
 
-    "noise_reduction_threshold",
-    "ir_gamma_correction",
-    "depth_correction",
-    "camera_geometry_correction",
-    "bayer_rgb_conversion",
-    "camera_distortion_correction",
-    "revision"};
+    "noise_reduction_threshold", "ir_gamma_correction",
+    "depth_correction",          "camera_geometry_correction",
+    "bayer_rgb_conversion",      "camera_distortion_correction",
+    "ir_distortion_correction",  "revision"};
 //one sensor constructor
 Camera3D_Smart::Camera3D_Smart(
     std::shared_ptr<aditof::DepthSensorInterface> rgbdSensor,
@@ -76,7 +73,7 @@ Camera3D_Smart::Camera3D_Smart(
       m_eepromInitialized(false), m_tempSensorsInitialized(false),
       m_availableControls(availableControls), m_depthCorrection(true),
       m_cameraGeometryCorrection(true), m_cameraDistortionCorrection(true),
-      m_revision("RevA") {
+      m_irDistorsionCorrection(false), m_revision("RevA") {
 
     m_Rw = 255.0 * 0.25;
     m_Gw = 255.0 * 0.35;
@@ -496,6 +493,8 @@ if (m_details.mode != skCustomMode &&
         m_calibration.distortionCorrection(depthDataLocation,
                                            m_details.frameType.width,
                                            m_details.frameType.height);
+    }
+    if (m_irDistorsionCorrection) {
         m_calibration.distortionCorrection(irDataLocation,
                                            m_details.frameType.width,
                                            m_details.frameType.height);
@@ -587,6 +586,9 @@ aditof::Status Camera3D_Smart::setControl(const std::string &control,
     if (control == "camera_distortion_correction") {
         m_cameraDistortionCorrection = std::stoi(value) != 0;
     }
+    if (control == "ir_distortion_correction") {
+        m_irDistorsionCorrection = std::stoi(value) != 0;
+    }
     return status;
 }
 
@@ -627,6 +629,10 @@ aditof::Status Camera3D_Smart::getControl(const std::string &control,
 
     if (control == "camera_distortion_correction") {
         value = m_cameraDistortionCorrection ? "1" : "0";
+    }
+
+    if (control == "ir_distorsion_correction") {
+        value = m_irDistorsionCorrection ? "1" : "0";
     }
 
     return status;

--- a/sdk/src/cameras/3d-smart-camera/camera_3d_smart.h
+++ b/sdk/src/cameras/3d-smart-camera/camera_3d_smart.h
@@ -128,6 +128,7 @@ class Camera3D_Smart : public aditof::Camera {
     bool m_cameraGeometryCorrection;
     bool m_cameraBayerRgbConversion;
     bool m_cameraDistortionCorrection;
+    bool m_irDistorsionCorrection;
     std::string m_revision;
     std::vector<aditof::FrameDetails> m_rgbdFrameTypes;
     float m_Rw;

--- a/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
+++ b/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.cpp
@@ -65,6 +65,7 @@ static const std::vector<std::string> availableControls = {
     "depth_correction",
     "camera_geometry_correction",
     "camera_distortion_correction",
+    "ir_distortion_correction",
     "revision"};
 
 Camera96Tof1::Camera96Tof1(
@@ -75,7 +76,7 @@ Camera96Tof1::Camera96Tof1(
       m_eepromInitialized(false), m_tempSensorsInitialized(false),
       m_availableControls(availableControls), m_depthCorrection(true),
       m_cameraGeometryCorrection(true), m_distortionCorrection(true),
-      m_revision("RevC") {
+      m_irDistorsionCorrection(false), m_revision("RevC") {
 
     // Check Depth Sensor
     if (!depthSensor) {
@@ -496,7 +497,7 @@ aditof::Status Camera96Tof1::requestFrame(aditof::Frame *frame,
     }
     if ((m_details.frameType.type == "depth_ir" ||
          m_details.frameType.type == "ir") &&
-        m_distortionCorrection) {
+        m_irDistorsionCorrection) {
         uint16_t *irDataLocation;
         frame->getData(FrameDataType::IR, &irDataLocation);
         m_calibration.distortionCorrection(irDataLocation,
@@ -588,6 +589,10 @@ aditof::Status Camera96Tof1::setControl(const std::string &control,
         m_revision = value;
     }
 
+    if (control == "ir_distorsion_correction") {
+        m_irDistorsionCorrection = std::stoi(value) != 0;
+    }
+
     return status;
 }
 
@@ -621,6 +626,10 @@ aditof::Status Camera96Tof1::getControl(const std::string &control,
 
     if (control == "camera_distortion_correction") {
         value = m_distortionCorrection ? "1" : "0";
+    }
+
+    if (control == "ir_distortion_correction") {
+        value = m_irDistorsionCorrection ? "1" : "0";
     }
 
     if (control == "revision") {

--- a/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.h
+++ b/sdk/src/cameras/ad-96tof1-ebz/camera_96tof1.h
@@ -100,6 +100,7 @@ class Camera96Tof1 : public aditof::Camera {
     bool m_depthCorrection;
     bool m_cameraGeometryCorrection;
     bool m_distortionCorrection;
+    bool m_irDistorsionCorrection;
     std::string m_revision;
 };
 

--- a/sdk/src/cameras/ad-fxtof1-ebz/camera_fxtof1.cpp
+++ b/sdk/src/cameras/ad-fxtof1-ebz/camera_fxtof1.cpp
@@ -64,6 +64,7 @@ static const std::vector<std::string> availableControls = {
     "depth_correction",
     "camera_geometry_correction",
     "camera_distortion_correction",
+    "ir_distortion_correction",
     "revision"};
 static const std::string skEepromName = "custom";
 CameraFxTof1::CameraFxTof1(
@@ -74,7 +75,7 @@ CameraFxTof1::CameraFxTof1(
       m_eepromInitialized(false), m_tempSensorsInitialized(false),
       m_availableControls(availableControls), m_depthCorrection(true),
       m_cameraGeometryCorrection(true), m_distortionCorrection(true),
-      m_revision("RevA") {
+      m_irDistorsionCorrection(false), m_revision("RevA") {
 
     // Check Depth Sensor
     if (!depthSensor) {
@@ -432,7 +433,7 @@ aditof::Status CameraFxTof1::requestFrame(aditof::Frame *frame,
 
     if ((m_details.frameType.type == "depth_ir" ||
          m_details.frameType.type == "ir") &&
-        m_distortionCorrection) {
+        m_irDistorsionCorrection) {
         uint16_t *irDataLocation;
         frame->getData(FrameDataType::IR, &irDataLocation);
 
@@ -517,6 +518,10 @@ aditof::Status CameraFxTof1::setControl(const std::string &control,
         m_distortionCorrection = std::stoi(value) != 0;
     }
 
+    if (control == "ir_distortion_correction") {
+        m_irDistorsionCorrection = std::stoi(value) != 0;
+    }
+
     if (control == "revision") {
         m_revision = value;
     }
@@ -554,6 +559,10 @@ aditof::Status CameraFxTof1::getControl(const std::string &control,
 
     if (control == "camera_distortion_correction") {
         value = m_distortionCorrection ? "1" : "0";
+    }
+
+    if (control == "ir_distorsion_correction") {
+        value = m_irDistorsionCorrection ? "1" : "0";
     }
 
     if (control == "revision") {

--- a/sdk/src/cameras/ad-fxtof1-ebz/camera_fxtof1.h
+++ b/sdk/src/cameras/ad-fxtof1-ebz/camera_fxtof1.h
@@ -100,6 +100,7 @@ class CameraFxTof1 : public aditof::Camera {
     bool m_depthCorrection;
     bool m_cameraGeometryCorrection;
     bool m_distortionCorrection;
+    bool m_irDistorsionCorrection;
     std::string m_revision;
 };
 


### PR DESCRIPTION
And make this option to be disabled by default. It lowers the FPS
especially on target.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>