### PR TITLE
Kuyper build problem solved

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -204,17 +204,18 @@ if( APPLE )
 endif( APPLE )
 
 #Systems that don't have builtin atomics, or don't have 8byte support need libatomic linking
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-    #include <atomic>
-        return std::atomic<int64_t>{};
-    }
-    " HAVE_BUILTIN_ATOMICS)
+if (UNIX)
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("
+        #include <atomic>
+            return std::atomic<int64_t>{};
+        }
+        " HAVE_BUILTIN_ATOMICS)
 
-if (NOT HAVE_BUILTIN_ATOMICS)
-    target_link_libraries(${PROJECT_NAME} PUBLIC atomic)
+    if (NOT HAVE_BUILTIN_ATOMICS)
+        target_link_libraries(${PROJECT_NAME} PUBLIC atomic)
+    endif()
 endif()
-
 
 # includes install paths
 include(GNUInstallDirs)

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -203,6 +203,19 @@ if( APPLE )
     target_link_libraries( ${PROJECT_NAME} PRIVATE ${LIBUVC_LIB})
 endif( APPLE )
 
+#Systems that don't have builtin atomics, or don't have 8byte support need libatomic linking
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+    #include <atomic>
+        return std::atomic<int64_t>{};
+    }
+    " HAVE_BUILTIN_ATOMICS)
+
+if (NOT HAVE_BUILTIN_ATOMICS)
+    target_link_libraries(${PROJECT_NAME} PUBLIC atomic)
+endif()
+
+
 # includes install paths
 include(GNUInstallDirs)
 


### PR DESCRIPTION
In case the system on which the sdk is built does not include atomic library by default, manual linking is done by the cmake.