### PR TITLE
Changed build configuration for JavaScript bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 
 if (WITH_JS)
     set(WITH_NETWORK OFF)
+    set(WITH_EXAMPLES OFF)
     add_definitions(-DJS_BINDINGS)
 endif()
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -123,8 +123,8 @@ file(GLOB NETWORK_HEADERS
 # Create target and set properties
 add_library(${PROJECT_NAME} SHARED
     ${SOURCES}
-    ${PLATFORM_SOURCES}
-    ${PLATFORM_HEADERS}
+    $<$<NOT:$<BOOL:${WITH_JS}>>:${PLATFORM_SOURCES}>
+    $<$<NOT:$<BOOL:${WITH_JS}>>:${PLATFORM_HEADERS}>
     $<$<BOOL:${ON_TARGET}>:${ONE_CAMERA_SOURCES}>
     $<$<BOOL:${ON_TARGET}>:${ONE_CAMERA_HEADERS}>
     $<$<NOT:$<BOOL:${ON_TARGET}>>:${ALL_CAMERAS_SOURCES}>


### PR DESCRIPTION
Signed-off-by: Timotei Molcut <timotei.molcut@analog.com>
JS bindings are generated using WITH_JS option. When creating the JS bindings, connections directory doesn't need to be added in the build.